### PR TITLE
System.Void as type param was a Mono <2.11 bug; replace with [new] Unit

### DIFF
--- a/XSharpx.csproj
+++ b/XSharpx.csproj
@@ -47,6 +47,7 @@
     <Compile Include="src\XSharpx\Either.cs" />
     <Compile Include="src\XSharpx\Tree.cs" />
     <Compile Include="src\XSharpx\Iteratee.cs" />
+    <Compile Include="src\XSharpx\Unit.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/XSharpx/Iteratee.cs
+++ b/src/XSharpx/Iteratee.cs
@@ -304,32 +304,32 @@ namespace XSharpx {
       return Iteratee<A, Option<A>>.Cont(step);
     }
 
-    public static Iteratee<A, Void> Drop<A>(int n) {
-      Iteratee<A, Void> eof = Iteratee<A, Void>.Done(default(Void), Input<A>.Eof());
-      Iteratee<A, Void> empty = Iteratee<A, Void>.Done(default(Void), Input<A>.Empty());
-      Func<Input<A>, Iteratee<A, Void>> step =
-        i => i.Fold<Iteratee<A, Void>>(
-          () => Iteratee<A, Void>.Cont(step)
+    public static Iteratee<A, Unit> Drop<A>(int n) {
+      Iteratee<A, Unit> eof = Iteratee<A, Unit>.Done(default(Unit), Input<A>.Eof());
+      Iteratee<A, Unit> empty = Iteratee<A, Unit>.Done(default(Unit), Input<A>.Empty());
+      Func<Input<A>, Iteratee<A, Unit>> step =
+        i => i.Fold<Iteratee<A, Unit>>(
+          () => Iteratee<A, Unit>.Cont(step)
         , () => eof
         , _ => Drop<A>(n - 1)
         );
 
       return n == 0 ?
         empty :
-        Iteratee<A, Void>.Cont(step);
+        Iteratee<A, Unit>.Cont(step);
     }
 
-    public static Iteratee<A, Void> DropWhile<A>(Func<A, bool> p) {
-      Func<Input<A>, Iteratee<A, Void>> v = i => Iteratee<A, Void>.Done(default(Void), i);
+    public static Iteratee<A, Unit> DropWhile<A>(Func<A, bool> p) {
+      Func<Input<A>, Iteratee<A, Unit>> v = i => Iteratee<A, Unit>.Done(default(Unit), i);
       var eof = v(Input<A>.Eof());
-      Func<Input<A>, Iteratee<A, Void>> step =
-        i => i.Fold<Iteratee<A, Void>>(
-          () => Iteratee<A, Void>.Cont(step)
+      Func<Input<A>, Iteratee<A, Unit>> step =
+        i => i.Fold<Iteratee<A, Unit>>(
+          () => Iteratee<A, Unit>.Cont(step)
         , () => eof
         , e => p(e) ? DropWhile(p) : v(i)
         );
 
-      return Iteratee<A, Void>.Cont(step);
+      return Iteratee<A, Unit>.Cont(step);
     }
 
     public static Iteratee<E, A> Fold<E, A>(Func<A, E, A> f, A z) {

--- a/src/XSharpx/Unit.cs
+++ b/src/XSharpx/Unit.cs
@@ -1,0 +1,30 @@
+namespace XSharpx {
+  /// <summary>
+  /// A value with only one instance, <see cref="Unit.Value"/>.
+  /// Unlike <see cref="System.Void"/>, can be legally used as a
+  /// generic type parameter.
+  /// </summary>
+  ///
+  /// <remarks>
+  /// <para>If you have <see cref="Microsoft.FSharp.Core.Unit">F#
+  /// Unit</see> available instead, use that; it's more
+  /// convenient.</para>
+  /// </remarks>
+  public struct Unit {
+    /// <summary>
+    /// The only Unit value.  Make your own if you like; they're all
+    /// the same.
+    /// </summary>
+    public static readonly Unit Value = new Unit();
+  }
+
+  public sealed class UnitInstances {
+    private UnitInstances() { }
+
+    /// <summary>
+    /// The trivial monoid of any singleton universe.
+    /// </summary>
+    public static readonly Monoid<Unit> Monoid =
+      Monoid<Unit>.monoid((a, b) => Unit.Value, Unit.Value);
+  }
+}


### PR DESCRIPTION
Void [invalid bytecode bug](https://bugzilla.xamarin.com/show_bug.cgi?id=3571); patched in mono/mono@197b3010ded36e63729bc26c573b90511f846595, which was released with Mono 2.11.0.

I add `XSharpx.Unit`, though it'd be nicer to just use F# Unit.
