### PR TITLE
update to C# 6

### DIFF
--- a/src/XSharpx/DiffList.cs
+++ b/src/XSharpx/DiffList.cs
@@ -11,71 +11,36 @@ namespace XSharpx {
       this.endo = endo;
     }
 
-    public List<A> Apply(List<A> a) {
-      return endo(a);
-    }
+    public List<A> Apply(List<A> a) => endo(a);
 
-    public List<A> ToList {
-      get {
-        return endo(List<A>.Empty);
-      }
-    }
+    public List<A> ToList => endo(List<A>.Empty);
 
-    public Option<A> Head {
-      get {
-        return ToList.Head;
-      }
-    }
+    public Option<A> Head => ToList.Head;
 
-    public Option<List<A>> Tail {
-      get {
-        return ToList.Tail;
-      }
-    }
+    public Option<List<A>> Tail => ToList.Tail;
 
-    public A HeadOr(Func<A> a) {
-      return Head.ValueOr(a);
-    }
+    public A HeadOr(Func<A> a) => Head.ValueOr(a);
 
-    public List<A> TailOr(Func<List<A>> a) {
-      return Tail.ValueOr(a);
-    }
+    public List<A> TailOr(Func<List<A>> a) =>Tail.ValueOr(a);
 
-    public bool IsEmpty {
-      get {
-        return ToList.IsEmpty;
-      }
-    }
+    public bool IsEmpty => ToList.IsEmpty;
 
-    public bool IsNotEmpty {
-      get {
-        return !IsEmpty;
-      }
-    }
+    public bool IsNotEmpty => !IsEmpty;
 
-    public DiffList<A> Where(Func<A, bool> f) {
-      return ToList.Where(f).ToDiffList;
-    }
+    public DiffList<A> Where(Func<A, bool> f) => ToList.Where(f).ToDiffList;
 
-    public B FoldRight<B>(Func<A, B, B> f, B b) {
-      return ToList.FoldRight(f, b);
-    }
+    public B FoldRight<B>(Func<A, B, B> f, B b) => ToList.FoldRight(f, b);
 
-    public B FoldLeft<B>(Func<B, A, B> f, B b) {
-      return ToList.FoldLeft(f, b);
-    }
+    public B FoldLeft<B>(Func<B, A, B> f, B b) => ToList.FoldLeft(f, b);
 
-    public DiffList<C> ProductWith<B, C>(DiffList<B> o, Func<A, Func<B, C>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public DiffList<C> ProductWith<B, C>(DiffList<B> o, Func<A, Func<B, C>> f) =>
+      this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public DiffList<Pair<A, B>> Product<B>(DiffList<B> o) {
-      return ProductWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
-    }
+    public DiffList<Pair<A, B>> Product<B>(DiffList<B> o) =>
+      ProductWith(o, Pair<A, B>.pairF());
 
-    public X Uncons<X>(Func<X> nil, Func<A, DiffList<A>, X> headTail) {
-      return ToList.Uncons(nil, (a, l) => headTail(a, l.ToDiffList));
-    }
+    public X Uncons<X>(Func<X> nil, Func<A, DiffList<A>, X> headTail) =>
+      ToList.Uncons(nil, (a, l) => headTail(a, l.ToDiffList));
 
     public static DiffList<A> diffList(params A[] a) {
       var k = DiffList<A>.Empty;
@@ -87,27 +52,18 @@ namespace XSharpx {
       return k;
     }
 
-    public static DiffList<A> operator +(A h, DiffList<A> t) {
-      return new DiffList<A>(l => h + t.endo(l));
-    }
+    public static DiffList<A> operator +(A h, DiffList<A> t) =>
+      new DiffList<A>(l => h + t.endo(l));
 
-    public static DiffList<A> operator +(DiffList<A> t, A r) {
-      return new DiffList<A>(l => t.endo(r + l));
-    }
+    public static DiffList<A> operator +(DiffList<A> t, A r) =>
+      new DiffList<A>(l => t.endo(r + l));
 
-    public static DiffList<A> operator *(DiffList<A> x, DiffList<A> y) {
-      return new DiffList<A>(l => x.endo(y.endo(l)));
-    }
+    public static DiffList<A> operator *(DiffList<A> x, DiffList<A> y) =>
+      new DiffList<A>(l => x.endo(y.endo(l)));
 
-    public static DiffList<A> diffList(Func<List<A>, List<A>> e) {
-      return new DiffList<A>(e);
-    }
+    public static DiffList<A> diffList(Func<List<A>, List<A>> e) => new DiffList<A>(e);
 
-    public static DiffList<A> Empty {
-      get {
-        return new DiffList<A>(l => l);
-      }
-    }
+    public static DiffList<A> Empty => new DiffList<A>(l => l);
 
     private class DiffListEnumerator : IEnumerator<A> {
       private readonly IEnumerator<A> e;
@@ -122,66 +78,43 @@ namespace XSharpx {
         e.Reset();
       }
 
-      public bool MoveNext() {
-        return e.MoveNext();
-      }
+      public bool MoveNext() => e.MoveNext();
 
-      A IEnumerator<A>.Current {
-        get {
-          return e.Current;
-        }
-      }
-
-      public object Current {
-        get {
-          return e.Current;
-        }
-      }
+      A IEnumerator<A>.Current => e.Current;
+      public object Current => e.Current;
     }
 
-    private DiffListEnumerator Enumerate() {
-      return new DiffListEnumerator((ToList as IEnumerable<A>).GetEnumerator());
-    }
+    private DiffListEnumerator Enumerate() => new DiffListEnumerator((ToList as IEnumerable<A>).GetEnumerator());
 
-    IEnumerator<A> IEnumerable<A>.GetEnumerator() {
-      return Enumerate();
-    }
+    IEnumerator<A> IEnumerable<A>.GetEnumerator() => Enumerate();
 
-    IEnumerator IEnumerable.GetEnumerator() {
-      return Enumerate();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => Enumerate();
   }
 
   public static class DiffListExtension {
-    public static DiffList<B> Select<A, B>(this DiffList<A> ps, Func<A, B> f) {
-      return ps.FoldRight((a, b) => f(a) + b, DiffList<B>.Empty);
-    }
+    public static DiffList<B> Select<A, B>(this DiffList<A> ps, Func<A, B> f) =>
+      ps.FoldRight((a, b) => f(a) + b, DiffList<B>.Empty);
 
-    public static DiffList<B> SelectMany<A, B>(this DiffList<A> ps, Func<A, DiffList<B>> f) {
-       return ps.FoldRight((a, b) => f(a) * b, DiffList<B>.Empty);
-    }
+    public static DiffList<B> SelectMany<A, B>(this DiffList<A> ps, Func<A, DiffList<B>> f) =>
+       ps.FoldRight((a, b) => f(a) * b, DiffList<B>.Empty);
 
-    public static DiffList<C> SelectMany<A, B, C>(this DiffList<A> ps, Func<A, DiffList<B>> p, Func<A, B, C> f) {
-      return SelectMany(ps, a => Select(p(a), b => f(a, b)));
-    }
+    public static DiffList<C> SelectMany<A, B, C>(this DiffList<A> ps, Func<A, DiffList<B>> p, Func<A, B, C> f) =>
+      SelectMany(ps, a => Select(p(a), b => f(a, b)));
+    
 
-    public static DiffList<B> Apply<A, B>(this DiffList<Func<A, B>> f, DiffList<A> o) {
-      return f.ProductWith<A, B>(o, a => b => a(b));
-    }
+    public static DiffList<B> Apply<A, B>(this DiffList<Func<A, B>> f, DiffList<A> o) =>
+      f.ProductWith<A, B>(o, a => b => a(b));
 
-    public static DiffList<A> Flatten<A>(this DiffList<DiffList<A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static DiffList<A> Flatten<A>(this DiffList<DiffList<A>> o) =>
+       o.SelectMany(z => z);
 
-    public static Pair<DiffList<A>, DiffList<B>> Unzip<A, B>(this DiffList<Pair<A, B>> p) {
-      return p.FoldRight<Pair<DiffList<A>, DiffList<B>>>(
+    public static Pair<DiffList<A>, DiffList<B>> Unzip<A, B>(this DiffList<Pair<A, B>> p) =>
+      p.FoldRight(
         (x, y) => (x._1.Get + y._1.Get).And(x._2.Get + y._2.Get)
       , DiffList<A>.Empty.And(DiffList<B>.Empty)
       );
-    }
 
-    public static DiffList<A> DiffListValue<A>(this A a) {
-      return DiffList<A>.diffList(l => a + l);
-    }
+    public static DiffList<A> DiffListValue<A>(this A a) =>
+      DiffList<A>.diffList(l => a + l);
   }
 }

--- a/src/XSharpx/Either.cs
+++ b/src/XSharpx/Either.cs
@@ -20,203 +20,131 @@ namespace XSharpx {
       this.b = b;
     }
 
-    public bool IsLeft {
-      get {
-        return l;
-      }
-    }
+    public bool IsLeft => l;
 
-    public bool IsRight {
-      get {
-        return !l;
-      }
-    }
+    public bool IsRight => !l;
 
-    public Either<C, D> BinarySelect<C, D>(Func<A, C> f, Func<B, D> g) {
-      return Fold(a => f(a).Left<C, D>(), b => g(b).Right<C, D>());
-    }
+    public Either<C, D> BinarySelect<C, D>(Func<A, C> f, Func<B, D> g) =>
+      Fold(a => f(a).Left<C, D>(), b => g(b).Right<C, D>());
 
-    public Either<A, Either<A, B>> Duplicate {
-      get {
-        return this.Select(b => b.Right<A, B>());
-      }
-    }
+    public Either<A, Either<A, B>> Duplicate =>
+      this.Select(b => b.Right<A, B>());
 
-    public Either<A, X> Extend<X>(Func<Either<A, B>, X> f) {
-      return this.Select(b => f(b.Right<A, B>()));
-    }
+    public Either<A, X> Extend<X>(Func<Either<A, B>, X> f) =>
+      this.Select(b => f(b.Right<A, B>()));
 
-    public Either<A, D> ZipWith<C, D>(Either<A, C> o, Func<B, Func<C, D>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public Either<A, D> ZipWith<C, D>(Either<A, C> o, Func<B, Func<C, D>> f) =>
+      this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public Either<A, B> OrElse(Func<Either<A, B>> o) {
-      return IsLeft ? o() : this;
-    }
+    public Either<A, B> OrElse(Func<Either<A, B>> o) =>
+      IsLeft ? o() : this;
 
-    public bool All(Func<B, bool> f) {
-      return IsLeft || f(b);
-    }
+    public bool All(Func<B, bool> f) => IsLeft || f(b);
 
-    public bool Any(Func<B, bool> f) {
-      return IsRight && f(b);
-    }
+    public bool Any(Func<B, bool> f) => IsRight && f(b);
 
-    public List<B> ToList {
-      get {
-        return IsLeft ? List<B>.Empty : b.ListValue();
-      }
-    }
+    public List<B> ToList => IsLeft ? List<B>.Empty : b.ListValue();
 
-    public Either<B, A> Swap {
-      get {
-        return l ? Either<B, A>.Right(a) : Either<B, A>.Left(b);
-      }
-    }
+    public Either<B, A> Swap => l ? Either<B, A>.Right(a) : Either<B, A>.Left(b);
 
-    public Either<A, B> Swapped(Func<Either<B, A>, Either<B, A>> f) {
-      return f(Swap).Swap;
-    }
+    public Either<A, B> Swapped(Func<Either<B, A>, Either<B, A>> f) =>
+      f(Swap).Swap;
 
-    public X Fold<X>(Func<A, X> left, Func<B, X> right) {
-      return l ? left(a) : right(b);
-    }
+    public X Fold<X>(Func<A, X> left, Func<B, X> right) => l ? left(a) : right(b);
 
     public void ForEach(Action<B> x) {
       if(IsRight)
         x(b);
     }
 
-    public B ValueOr(Func<B> x) {
-      return IsLeft ? x() : b;
-    }
+    public B ValueOr(Func<B> x) => IsLeft ? x() : b;
 
-    public B Reduce(Func<A, B> f) {
-      return IsLeft ? f(a) : b;
-    }
+    public B Reduce(Func<A, B> f) => IsLeft ? f(a) : b;
 
-    public Either<A, B> Ensure(Func<B, bool> p, Func<A> or) {
-      return this.SelectMany(b => p(b) ? b.Right<A, B>() : or().Left<A, B>());
-    }
+    public Either<A, B> Ensure(Func<B, bool> p, Func<A> or) =>
+      this.SelectMany(b => p(b) ? b.Right<A, B>() : or().Left<A, B>());
 
-    public Option<B> ToOption {
-      get {
-        return IsLeft ? Option<B>.Empty : b.Some ();
-      }
-    }
+    public Option<B> ToOption => IsLeft ? Option<B>.Empty : b.Some();
 
-    public List<Either<A, X>> TraverseList<X>(Func<B, List<X>> f) {
-      return Fold(a => a.Left<A, X>().ListValue(), b => f(b).Select(x => x.Right<A, X>()));
-    }
+    public List<Either<A, X>> TraverseList<X>(Func<B, List<X>> f) =>
+      Fold(a => a.Left<A, X>().ListValue(), b => f(b).Select(x => x.Right<A, X>()));
 
-    public Option<Either<A, X>> TraverseOption<X>(Func<B, Option<X>> f) {
-      return Fold(a => a.Left<A, X>().Some(), b => f(b).Select(x => x.Right<A, X>()));
-    }
+    public Option<Either<A, X>> TraverseOption<X>(Func<B, Option<X>> f) =>
+      Fold(a => a.Left<A, X>().Some(), b => f(b).Select(x => x.Right<A, X>()));
 
-    public Terminal<Either<A, X>> TraverseTerminal<X>(Func<B, Terminal<X>> f) {
-      return Fold(a => a.Left<A, X>().TerminalValue(), b => f(b).Select(x => x.Right<A, X>()));
-    }
+    public Terminal<Either<A, X>> TraverseTerminal<X>(Func<B, Terminal<X>> f) =>
+      Fold(a => a.Left<A, X>().TerminalValue(), b => f(b).Select(x => x.Right<A, X>()));
 
-    public Input<Either<A, X>> TraverseInput<X>(Func<B, Input<X>> f) {
-      return Fold(a => a.Left<A, X>().InputElement(), b => f(b).Select(x => x.Right<A, X>()));
-    }
+    public Input<Either<A, X>> TraverseInput<X>(Func<B, Input<X>> f) =>
+      Fold(a => a.Left<A, X>().InputElement(), b => f(b).Select(x => x.Right<A, X>()));
 
-    public Either<W, Either<A, X>> TraverseEither<W, X>(Func<B, Either<W, X>> f) {
-      return Fold(a => a.Left<A, X>().Right<W, Either<A, X>>(), b => f(b).Select(x => x.Right<A, X>()));
-    }
+    public Either<W, Either<A, X>> TraverseEither<W, X>(Func<B, Either<W, X>> f) =>
+      Fold(a => a.Left<A, X>().Right<W, Either<A, X>>(), b => f(b).Select(x => x.Right<A, X>()));
 
-    public NonEmptyList<Either<A, X>> TraverseNonEmptyList<X>(Func<B, NonEmptyList<X>> f) {
-      return Fold(a => a.Left<A, X>().NonEmptyListValue(), b => f(b).Select(x => x.Right<A, X>()));
-    }
+    public NonEmptyList<Either<A, X>> TraverseNonEmptyList<X>(Func<B, NonEmptyList<X>> f) =>
+      Fold(a => a.Left<A, X>().NonEmptyListValue(), b => f(b).Select(x => x.Right<A, X>()));
 
-    public Pair<W, Either<A, X>> TraversePair<W, X>(Func<B, Pair<W, X>> f, Monoid<W> m) {
-      return Fold(a => m.Id.And(a.Left<A, X>()), b => f(b).Select(x => x.Right<A, X>()));
-    }
+    public Pair<W, Either<A, X>> TraversePair<W, X>(Func<B, Pair<W, X>> f, Monoid<W> m) =>
+      Fold(a => m.Id.And(a.Left<A, X>()), b => f(b).Select(x => x.Right<A, X>()));
 
-    public Func<W, Either<A, X>> TraverseFunc<W, X>(Func<B, Func<W, X>> f) {
-      return Fold<Func<W, Either<A, X>>>(a => _ => a.Left<A, X>(), b => f(b).Select(x => x.Right<A, X>()));
-    }
+    public Func<W, Either<A, X>> TraverseFunc<W, X>(Func<B, Func<W, X>> f) =>
+      Fold(a => _ => a.Left<A, X>(), b => f(b).Select(x => x.Right<A, X>()));
 
-    public Tree<Either<A, X>> TraverseTree<X>(Func<B, Tree<X>> f) {
-      return Fold(a => a.Left<A, X>().TreeValue(), b => f(b).Select(x => x.Right<A, X>()));
-    }
+    public Tree<Either<A, X>> TraverseTree<X>(Func<B, Tree<X>> f) =>
+      Fold(a => a.Left<A, X>().TreeValue(), b => f(b).Select(x => x.Right<A, X>()));
 
-    public List<Either<X, Y>> BinaryTraverseList<X, Y>(Func<A, List<X>> f, Func<B, List<Y>> g) {
-      return Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
-    }
+    public List<Either<X, Y>> BinaryTraverseList<X, Y>(Func<A, List<X>> f, Func<B, List<Y>> g) =>
+      Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
 
-    public Option<Either<X, Y>> BinaryTraverseOption<X, Y>(Func<A, Option<X>> f, Func<B, Option<Y>> g) {
-      return Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
-    }
+    public Option<Either<X, Y>> BinaryTraverseOption<X, Y>(Func<A, Option<X>> f, Func<B, Option<Y>> g) =>
+      Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
 
-    public Either<W, Either<X, Y>> BinaryTraverseEither<W, X, Y>(Func<A, Either<W, X>> f, Func<B, Either<W, Y>> g) {
-      return Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
-    }
+    public Either<W, Either<X, Y>> BinaryTraverseEither<W, X, Y>(Func<A, Either<W, X>> f, Func<B, Either<W, Y>> g) =>
+      Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
 
-    public NonEmptyList<Either<X, Y>> BinaryTraverseNonEmptyList<X, Y>(Func<A, NonEmptyList<X>> f, Func<B, NonEmptyList<Y>> g) {
-      return Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
-    }
+    public NonEmptyList<Either<X, Y>> BinaryTraverseNonEmptyList<X, Y>(Func<A, NonEmptyList<X>> f, Func<B, NonEmptyList<Y>> g) =>
+      Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
 
-    public Pair<W, Either<X, Y>> BinaryTraversePair<W, X, Y>(Func<A, Pair<W, X>> f, Func<B, Pair<W, Y>> g) {
-      return Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
-    }
+    public Pair<W, Either<X, Y>> BinaryTraversePair<W, X, Y>(Func<A, Pair<W, X>> f, Func<B, Pair<W, Y>> g) =>
+      Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
 
-    public Func<W, Either<X, Y>> BinaryTraverseFunc<W, X, Y>(Func<A, Func<W, X>> f, Func<B, Func<W, Y>> g) {
-      return Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
-    }
+    public Func<W, Either<X, Y>> BinaryTraverseFunc<W, X, Y>(Func<A, Func<W, X>> f, Func<B, Func<W, Y>> g) =>
+      Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
 
-    public Tree<Either<X, Y>> BinaryTraverseTree<X, Y>(Func<A, Tree<X>> f, Func<B, Tree<Y>> g) {
-      return Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
-    }
+    public Tree<Either<X, Y>> BinaryTraverseTree<X, Y>(Func<A, Tree<X>> f, Func<B, Tree<Y>> g) =>
+      Fold(a => f(a).Select(x => x.Left<X, Y>()), b => g(b).Select(y => y.Right<X, Y>()));
+    IEnumerator<B> IEnumerable<B>.GetEnumerator() =>
+      ((IEnumerable<B>) ToOption).GetEnumerator();
 
-    IEnumerator<B> IEnumerable<B>.GetEnumerator() {
-      return ((IEnumerable<B>) ToOption).GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() =>
+      ((IEnumerable) ToOption).GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() {
-      return ((IEnumerable) ToOption).GetEnumerator();
-    }
+    public static Either<A, B> Left(A a) =>
+      new Either<A, B>(true, a, default(B));
 
-    public static Either<A, B> Left(A a) {
-      return new Either<A, B>(true, a, default(B));
-    }
-
-    public static Either<A, B> Right(B b) {
-      return new Either<A, B>(false, default(A), b);
-    }
+    public static Either<A, B> Right(B b) =>
+      new Either<A, B>(false, default(A), b);
   }
 
   public static class EitherExtension {
-    public static Either<X, B> Select<X, A, B>(this Either<X, A> k, Func<A, B> f) {
-      return k.Fold(x => Either<X, B>.Left(x), a => Either<X, B>.Right(f(a)));
-    }
+    public static Either<X, B> Select<X, A, B>(this Either<X, A> k, Func<A, B> f) =>
+      k.Fold(x => Either<X, B>.Left(x), a => Either<X, B>.Right(f(a)));
 
-    public static Either<X, B> SelectMany<X, A, B>(this Either<X, A> k, Func<A, Either<X, B>> f) {
-      return k.Fold(x => Either<X, B>.Left(x), f);
-    }
+    public static Either<X, B> SelectMany<X, A, B>(this Either<X, A> k, Func<A, Either<X, B>> f) =>
+      k.Fold(x => Either<X, B>.Left(x), f);
 
-    public static Either<X, C> SelectMany<X, A, B, C>(this Either<X, A> k, Func<A, Either<X, B>> p, Func<A, B, C> f) {
-      return SelectMany(k, a => Select(p(a), b => f(a, b)));
-    }
+    public static Either<X, C> SelectMany<X, A, B, C>(this Either<X, A> k, Func<A, Either<X, B>> p, Func<A, B, C> f) =>
+      SelectMany(k, a => Select(p(a), b => f(a, b)));
 
-    public static Either<X, B> Apply<X, A, B>(this Either<X, Func<A, B>> f, Either<X, A> o) {
-      return f.SelectMany(g => o.Select(p => g(p)));
-    }
+    public static Either<X, B> Apply<X, A, B>(this Either<X, Func<A, B>> f, Either<X, A> o) =>
+      f.SelectMany(g => o.Select(p => g(p)));
 
-    public static Either<X, A> Flatten<X, A>(this Either<X, Either<X, A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static Either<X, A> Flatten<X, A>(this Either<X, Either<X, A>> o) => o.SelectMany(z => z);
 
-    public static Pair<Either<X, A>, Either<X, B>> Unzip<X, A, B>(this Either<X, Pair<A, B>> p) {
-      return p.Select(q => q._1.Get).And(p.Select(q => q._2.Get));
-    }
+    public static Pair<Either<X, A>, Either<X, B>> Unzip<X, A, B>(this Either<X, Pair<A, B>> p) => p.Select(q => q._1.Get).And(p.Select(q => q._2.Get));
 
-    public static Either<A, B> Left<A, B>(this A a) {
-      return Either<A, B>.Left(a);
-    }
+    public static Either<A, B> Left<A, B>(this A a) => Either<A, B>.Left(a);
 
-    public static Either<A, B> Right<A, B>(this B b) {
-      return Either<A, B>.Right(b);
-    }
+    public static Either<A, B> Right<A, B>(this B b) => Either<A, B>.Right(b);
   }
 }

--- a/src/XSharpx/FuncExtension.cs
+++ b/src/XSharpx/FuncExtension.cs
@@ -3,78 +3,45 @@ using System;
 namespace XSharpx {
   public static class FuncExtension {
     // 0-arity
-    public static Func<B> Select<A, B>(this Func<A> a, Func<A, B> f) {
-      return () => f(a());
-    }
+    public static Func<B> Select<A, B>(this Func<A> a, Func<A, B> f) => () => f(a());
 
-    public static Func<B> SelectMany<A, B>(this Func<A> a, Func<A, Func<B>> f) {
-      return f(a());
-    }
+    public static Func<B> SelectMany<A, B>(this Func<A> a, Func<A, Func<B>> f) => f(a());
 
-    public static Func<C> SelectMany<A, B, C>(this Func<A> k, Func<A, Func<B>> p, Func<A, B, C> f) {
-      return SelectMany<A, C>(k, a => Select<B, C>(p(a), b => f(a, b)));
-    }
+    public static Func<C> SelectMany<A, B, C>(this Func<A> k, Func<A, Func<B>> p, Func<A, B, C> f) =>
+      SelectMany(k, a => Select(p(a), b => f(a, b)));
 
-    public static Func<B> Apply<A, B>(this Func<Func<A, B>> a, Func<A> f) {
-      return () => a()(f());
-    }
+    public static Func<B> Apply<A, B>(this Func<Func<A, B>> a, Func<A> f) => () => a()(f());
 
-    public static Func<A> Flatten<A>(this Func<Func<A>> f) {
-      return SelectMany(f, z => z);
-    }
+    public static Func<A> Flatten<A>(this Func<Func<A>> f) => SelectMany(f, z => z);
 
     // 1-arity
-    public static Func<A, C> Select<A, B, C>(this Func<A, B> f, Func<B, C> g) {
-      return a => g(f(a));
-    }
+    public static Func<A, C> Select<A, B, C>(this Func<A, B> f, Func<B, C> g) => a => g(f(a));
 
-    public static Func<C, B> SelectMany<A, B, C>(this Func<C, A> f, Func<A, Func<C, B>> g) {
-      return a => g(f(a))(a);
-    }
+    public static Func<C, B> SelectMany<A, B, C>(this Func<C, A> f, Func<A, Func<C, B>> g) => a => g(f(a))(a);
 
-    public static Func<C, D> SelectMany<A, B, C, D>(this Func<C, A> f, Func<A, Func<C, B>> p, Func<A, B, D> k) {
-      return SelectMany<A, D, C>(f, b => Select<C, B, D>(p(b), x => k(b, x)));
-    }
+    public static Func<C, D> SelectMany<A, B, C, D>(this Func<C, A> f, Func<A, Func<C, B>> p, Func<A, B, D> k) =>
+      SelectMany(f, b => Select(p(b), x => k(b, x)));
 
-    public static Func<A, C> Apply<A, B, C>(this Func<A, Func<B, C>> f, Func<A, B> g) {
-      return a => f(a)(g(a));
-    }
+    public static Func<A, C> Apply<A, B, C>(this Func<A, Func<B, C>> f, Func<A, B> g) => a => f(a)(g(a));
 
-    public static Func<A, B> Flatten<A, B>(this Func<A, Func<A, B>> f) {
-      return SelectMany(f, z => z);
-    }
+    public static Func<A, B> Flatten<A, B>(this Func<A, Func<A, B>> f) => SelectMany(f, z => z);
 
-    public static Func<X, C> ZipWith<A, B, C, X>(this Func<X, A> a, Func<X, B> b, Func<A, Func<B, C>> f) {
-      return x => f(a(x))(b(x));
-    }
+    public static Func<X, C> ZipWith<A, B, C, X>(this Func<X, A> a, Func<X, B> b, Func<A, Func<B, C>> f) => x => f(a(x))(b(x));
 
-    public static Func<X, Pair<A, B>> Zip<A, B, X>(this Func<X, A> a, Func<X, B> b) {
-      return ZipWith<A, B, Pair<A, B>, X>(a, b, Pair<A, B>.pairF());
-    }
+    public static Func<X, Pair<A, B>> Zip<A, B, X>(this Func<X, A> a, Func<X, B> b) =>
+      ZipWith(a, b, Pair<A, B>.pairF());
 
-    public static Func<B, A, C> Flip<A, B, C>(this Func<A, B, C> f) {
-      return (b, a) => f(a, b);
-    }
+    public static Func<B, A, C> Flip<A, B, C>(this Func<A, B, C> f) => (b, a) => f(a, b);
 
-    public static Func<A, Func<B, C>> Curry<A, B, C>(this Func<A, B, C> f) {
-      return a => b => f(a, b);
-    }
+    public static Func<A, Func<B, C>> Curry<A, B, C>(this Func<A, B, C> f) => a => b => f(a, b);
 
-    public static Func<A, B, C> UnCurry<A, B, C>(this Func<A, Func<B, C>> f) {
-      return (a, b) => f(a)(b);
-    }
+    public static Func<A, B, C> UnCurry<A, B, C>(this Func<A, Func<B, C>> f) => (a, b) => f(a)(b);
 
-    public static Func<A, C> Compose<A, B, C>(this Func<B, C> f, Func<A, B> g) {
-      return a => f(g(a));
-    }
+    public static Func<A, C> Compose<A, B, C>(this Func<B, C> f, Func<A, B> g) => a => f(g(a));
 
-    public static Func<A, B> Constant<A, B>(this Func<B> f) {
-      return _ => f();
-    }
+    public static Func<A, B> Constant<A, B>(this Func<B> f) => _ => f();
 
-    public static Func<A, Func<B>> Promote<A, B>(this Func<A, B> f) {
-      return a => () => f(a);
-    }
+    public static Func<A, Func<B>> Promote<A, B>(this Func<A, B> f) => a => () => f(a);
 
   }
 }

--- a/src/XSharpx/Iteratee.cs
+++ b/src/XSharpx/Iteratee.cs
@@ -123,9 +123,8 @@ namespace XSharpx {
 
     public Either<Pair<A, Input<E>>, Func<Input<E>, Iteratee<E, A>>> ToEither => val;
 
-    public X Fold<X>(Func<A, Input<E>, X> done, Func<Func<Input<E>, Iteratee<E, A>>, X> cont) {
-      throw new NotImplementedException("Fold not implemented on Iteratee");
-    }
+    public X Fold<X>(Func<A, Input<E>, X> done, Func<Func<Input<E>, Iteratee<E, A>>, X> cont) => 
+      val.Fold(pair => pair.Fold(done), cont);
 
     public Iteratee<E, C> ZipWith<B, C>(Iteratee<E, B> o, Func<A, Func<B, C>> f) =>
       this.SelectMany(a => o.Select(b => f(a)(b)));

--- a/src/XSharpx/Iteratee.cs
+++ b/src/XSharpx/Iteratee.cs
@@ -11,49 +11,24 @@ namespace XSharpx {
       this.val = val;
     }
 
-    public X Fold<X>(Func<X> empty, Func<X> eof, Func<E, X> element) {
-      return val.Fold<X>(o => o.Fold(element, eof), empty);
-    }
+    public X Fold<X>(Func<X> empty, Func<X> eof, Func<E, X> element) =>
+      val.Fold<X>(o => o.Fold(element, eof), empty);
 
-    public bool IsEmpty {
-      get {
-        return val.IsEmpty;
-      }
-    }
+    public bool IsEmpty => val.IsEmpty;
 
-    public bool IsEof {
-      get {
-        return val.Any(o => o.IsEmpty);
-      }
-    }
+    public bool IsEof => val.Any(o => o.IsEmpty);
 
-    public bool IsElement {
-      get {
-        return val.Any(o => o.IsNotEmpty);
-      }
-    }
+    public bool IsElement => val.Any(o => o.IsNotEmpty);
 
-    public Option<E> InputElement {
-      get {
-        return val.Flatten();
-      }
-    }
+    public Option<E> InputElement => val.Flatten();
 
-    public E InputElementOr(Func<E> f) {
-      return InputElement.ValueOr(f);
-    }
+    public E InputElementOr(Func<E> f) => InputElement.ValueOr(f);
 
-    public Input<E> OrElse(Func<Input<E>> i) {
-      return IsElement ? this : i();
-    }
+    public Input<E> OrElse(Func<Input<E>> i) => IsElement ? this : i();
 
-    public Input<E> Append(Input<E> o, Semigroup<E> m) {
-      return m.Input.Op(this, o);
-    }
+    public Input<E> Append(Input<E> o, Semigroup<E> m) => m.Input.Op(this, o);
 
-    public Iteratee<E, A> Done<A>(A a) {
-      return Iteratee<E, A>.Done(a, this);
-    }
+    public Iteratee<E, A> Done<A>(A a) => Iteratee<E, A>.Done(a, this);
 
     public Input<E> Where(Func<E, bool> p) {
       var z = InputElement;
@@ -61,123 +36,82 @@ namespace XSharpx {
       return IsEmpty || IsEof ? this : z.Any(p) ? this : Empty();
     }
 
-    public Input<Input<E>> Duplicate {
-      get {
-        return this.Select(a => Element(a));
-      }
-    }
+    public Input<Input<E>> Duplicate => this.Select(a => Element(a));
 
-    public Input<B> Extend<B>(Func<Input<E>, B> f) {
-      return this.Select(a => f(Element(a)));
-    }
+    public Input<B> Extend<B>(Func<Input<E>, B> f) => this.Select(a => f(Element(a)));
 
-    public Input<C> ZipWith<B, C>(Input<B> o, Func<E, Func<B, C>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public Input<C> ZipWith<B, C>(Input<B> o, Func<E, Func<B, C>> f) => this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public Input<Pair<E, B>> Zip<B>(Input<B> o) {
-      return ZipWith<B, Pair<E, B>>(o, Pair<E, B>.pairF());
-    }
+    public Input<Pair<E, B>> Zip<B>(Input<B> o) => ZipWith(o, Pair<E, B>.pairF());
 
-    public bool Any(Func<E, bool> p) {
-      return val.Any(o => o.Any(p));
-    }
+    public bool Any(Func<E, bool> p) => val.Any(o => o.Any(p));
 
-    public bool All(Func<E, bool> p) {
-      return val.All(o => o.All(p));
-    }
+    public bool All(Func<E, bool> p) => val.All(o => o.All(p));
 
     public void ForEach(Action<E> a) {
       val.ForEach(o => o.ForEach(a));
     }
 
-    public List<E> ToList {
-      get {
-        return InputElement.ToList;
-      }
-    }
+    public List<E> ToList => InputElement.ToList;
 
-    public IEnumerator<E> GetEnumerator() {
-      return val.Flatten().GetEnumerator();
-    }
+    public IEnumerator<E> GetEnumerator() => val.Flatten().GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() {
-      return GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    public List<Input<B>> TraverseList<B>(Func<E, List<B>> f) {
-      return val.TraverseList(o => o.TraverseList(f)).Select(o => new Input<B>(o));
-    }
+    public List<Input<B>> TraverseList<B>(Func<E, List<B>> f) =>
+      val.TraverseList(o => o.TraverseList(f)).Select(o => new Input<B>(o));
 
-    public Option<Input<B>> TraverseOption<B>(Func<E, Option<B>> f) {
-      return val.TraverseOption(o => o.TraverseOption(f)).Select(o => new Input<B>(o));
-    }
+    public Option<Input<B>> TraverseOption<B>(Func<E, Option<B>> f) =>
+      val.TraverseOption(o => o.TraverseOption(f)).Select(o => new Input<B>(o));
 
-    public Terminal<Input<B>> TraverseTerminal<B>(Func<E, Terminal<B>> f) {
-      return val.TraverseTerminal(o => o.TraverseTerminal(f)).Select(o => new Input<B>(o));
-    }
+    public Terminal<Input<B>> TraverseTerminal<B>(Func<E, Terminal<B>> f) =>
+      val.TraverseTerminal(o => o.TraverseTerminal(f)).Select(o => new Input<B>(o));
 
-    public Input<Input<B>> TraverseInput<B>(Func<E, Input<B>> f) {
-      return val.TraverseInput(o => o.TraverseInput(f)).Select(o => new Input<B>(o));
-    }
+    public Input<Input<B>> TraverseInput<B>(Func<E, Input<B>> f) =>
+      val.TraverseInput(o => o.TraverseInput(f)).Select(o => new Input<B>(o));
 
-    public Either<X, Input<B>> TraverseEither<X, B>(Func<E, Either<X, B>> f) {
-      return val.TraverseEither(o => o.TraverseEither(f)).Select(o => new Input<B>(o));
-    }
+    public Either<X, Input<B>> TraverseEither<X, B>(Func<E, Either<X, B>> f) =>
+      val.TraverseEither(o => o.TraverseEither(f)).Select(o => new Input<B>(o));
 
-    public NonEmptyList<Input<B>> TraverseNonEmptyList<B>(Func<E, NonEmptyList<B>> f) {
-      return val.TraverseNonEmptyList(o => o.TraverseNonEmptyList(f)).Select(o => new Input<B>(o));
-    }
+    public NonEmptyList<Input<B>> TraverseNonEmptyList<B>(Func<E, NonEmptyList<B>> f) =>
+      val.TraverseNonEmptyList(o => o.TraverseNonEmptyList(f)).Select(o => new Input<B>(o));
 
-    public Pair<X, Input<B>> TraversePair<X, B>(Func<E, Pair<X, B>> f, Monoid<X> m) {
-      return val.TraversePair(o => o.TraversePair(f, m), m).Select(o => new Input<B>(o));
-    }
+    public Pair<X, Input<B>> TraversePair<X, B>(Func<E, Pair<X, B>> f, Monoid<X> m) =>
+      val.TraversePair(o => o.TraversePair(f, m), m).Select(o => new Input<B>(o));
 
-    public Func<X, Input<B>> TraverseFunc<X, B>(Func<E, Func<X, B>> f) {
-      return val.TraverseFunc<X, Option<B>>(o => o.TraverseFunc<X, B>(f)).Select(o => new Input<B>(o));
-    }
+    public Func<X, Input<B>> TraverseFunc<X, B>(Func<E, Func<X, B>> f) =>
+      val.TraverseFunc(o => o.TraverseFunc(f)).Select(o => new Input<B>(o));
 
-    public Tree<Input<B>> TraverseTree<B>(Func<E, Tree<B>> f) {
-      return val.TraverseTree(o => o.TraverseTree(f)).Select(o => new Input<B>(o));
-    }
 
-    public static Input<E> Empty() {
-      return new Input<E>(Option.Empty);
-    }
+    public Tree<Input<B>> TraverseTree<B>(Func<E, Tree<B>> f) =>
+      val.TraverseTree(o => o.TraverseTree(f)).Select(o => new Input<B>(o));
 
-    public static Input<E> Eof() {
-      return new Input<E>(Option.Some(Option<E>.Empty));
-    }
+    public static Input<E> Empty() => new Input<E>(Option.Empty);
 
-    public static Input<E> Element(E e) {
-      return new Input<E>(Option.Some(Option.Some(e)));
-    }
+    public static Input<E> Eof() => new Input<E>(Option.Some(Option<E>.Empty));
+
+    public static Input<E> Element(E e) => new Input<E>(Option.Some(Option.Some(e)));
+
   }
 
   public static class InputExtension {
-    public static Input<B> Select<A, B>(this Input<A> k, Func<A, B> f) {
-      return new Input<B>(k.val.Select(o => o.Select(f)));
-    }
+    public static Input<B> Select<A, B>(this Input<A> k, Func<A, B> f) =>
+      new Input<B>(k.val.Select(o => o.Select(f)));
 
-    public static Input<B> SelectMany<A, B>(this Input<A> k, Func<A, Input<B>> f) {
-      return new Input<B>(k.val.SelectMany(o => o.SelectMany(a => f(a).val)));
-    }
+    public static Input<B> SelectMany<A, B>(this Input<A> k, Func<A, Input<B>> f) =>
+      new Input<B>(k.val.SelectMany(o => o.SelectMany(a => f(a).val)));
 
-    public static Input<C> SelectMany<A, B, C>(this Input<A> k, Func<A, Input<B>> p, Func<A, B, C> f) {
-      return SelectMany(k, a => Select(p(a), b => f(a, b)));
-    }
+    public static Input<C> SelectMany<A, B, C>(this Input<A> k, Func<A, Input<B>> p, Func<A, B, C> f) =>
+      SelectMany(k, a => Select(p(a), b => f(a, b)));
 
-    public static Input<B> Apply<A, B>(this Input<Func<A, B>> f, Input<A> o) {
-      return f.SelectMany(g => o.Select(p => g(p)));
-    }
+    public static Input<B> Apply<A, B>(this Input<Func<A, B>> f, Input<A> o) =>
+      f.SelectMany(g => o.Select(p => g(p)));
 
-    public static Input<A> Flatten<A>(this Input<Input<A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static Input<A> Flatten<A>(this Input<Input<A>> o) =>
+      o.SelectMany(z => z);
 
-    public static Input<A> InputElement<A>(this A a) {
-      return Input<A>.Element(a);
-    }
+    public static Input<A> InputElement<A>(this A a) => Input<A>.Element(a);
+
   }
 
   public struct Iteratee<E, A> {
@@ -187,107 +121,53 @@ namespace XSharpx {
       this.val = val;
     }
 
-    public Either<Pair<A, Input<E>>, Func<Input<E>, Iteratee<E, A>>> ToEither {
-      get {
-        return val;
-      }
-    }
+    public Either<Pair<A, Input<E>>, Func<Input<E>, Iteratee<E, A>>> ToEither => val;
 
     public X Fold<X>(Func<A, Input<E>, X> done, Func<Func<Input<E>, Iteratee<E, A>>, X> cont) {
-      return default(X);
+      throw new NotImplementedException("Fold not implemented on Iteratee");
     }
 
-    public Iteratee<E, C> ZipWith<B, C>(Iteratee<E, B> o, Func<A, Func<B, C>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public Iteratee<E, C> ZipWith<B, C>(Iteratee<E, B> o, Func<A, Func<B, C>> f) =>
+      this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public Iteratee<D, A> ContraSelect<D>(Func<D, E> f) {
-      return Fold(
+    public Iteratee<D, A> ContraSelect<D>(Func<D, E> f) =>
+      Fold(
         (a, i) => Iteratee<D, A>.Done(a, i.IsEof ? Input<D>.Eof() : Input<D>.Empty())
       , r => Iteratee<D, A>.Cont(i => r(i.Select(f)).ContraSelect(f))
       );
-    }
 
-    public Iteratee<E, Pair<A, B>> Zip<B>(Iteratee<E, B> o) {
-      return ZipWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
-    }
+    public Iteratee<E, Pair<A, B>> Zip<B>(Iteratee<E, B> o) => ZipWith(o, Pair<A, B>.pairF());
 
-    public Option<Pair<A, Input<E>>> DoneT {
-      get {
-        return val.Swap.ToOption;
-      }
-    }
+    public Option<Pair<A, Input<E>>> DoneT => val.Swap.ToOption;
 
-    public Option<A> DoneA {
-      get {
-        return DoneT.Select(x => x._1.Get);
-      }
-    }
+    public Option<A> DoneA => DoneT.Select(x => x._1.Get);
 
-    public Option<Input<E>> DoneI {
-      get {
-        return DoneT.Select(x => x._2.Get);
-      }
-    }
+    public Option<Input<E>> DoneI => DoneT.Select(x => x._2.Get);
 
-    public bool IsDone {
-      get {
-        return DoneI.IsNotEmpty;
-      }
-    }
+    public bool IsDone => DoneI.IsNotEmpty;
 
-    public bool IsDoneEmpty {
-      get {
-        return DoneI.Any(i => i.IsEmpty);
-      }
-    }
+    public bool IsDoneEmpty => DoneI.Any(i => i.IsEmpty);
 
-    public bool IsDoneEof {
-      get {
-        return DoneI.Any(i => i.IsEof);
-      }
-    }
+    public bool IsDoneEof => DoneI.Any(i => i.IsEof);
+    public bool isDoneElement => DoneI.Any(i => i.IsElement);
 
-    public bool isDoneElement {
-      get {
-        return DoneI.Any(i => i.IsElement);
-      }
-    }
+    public Option<E> InputElement => DoneI.SelectMany(i => i.InputElement);
 
-    public Option<E> InputElement {
-      get {
-        return DoneI.SelectMany(i => i.InputElement);
-      }
-    }
+    public Option<Func<Input<E>, Iteratee<E, A>>> ContT => val.ToOption;
 
-    public Option<Func<Input<E>, Iteratee<E, A>>> ContT {
-      get {
-        return val.ToOption;
-      }
-    }
+    public bool IsCont => ContT.IsNotEmpty;
 
-    public bool IsCont {
-      get {
-        return ContT.IsNotEmpty;
-      }
-    }
+    public Option<Iteratee<E, A>> ApplyCont(Input<E> i) => ContT.Select(f => f(i));
 
-    public Option<Iteratee<E, A>> ApplyCont(Input<E> i) {
-      return ContT.Select(f => f(i));
-    }
+    public static Iteratee<E, A> Done(A a, Input<E> i) =>
+      new Iteratee<E, A>(Pair<A, Input<E>>.pair(a, i).Left<Pair<A, Input<E>>, Func<Input<E>, Iteratee<E, A>>>());
 
-    public static Iteratee<E, A> Done(A a, Input<E> i) {
-      return new Iteratee<E, A>(Pair<A, Input<E>>.pair(a, i).Left<Pair<A, Input<E>>, Func<Input<E>, Iteratee<E, A>>>());
-    }
+    public static Iteratee<E, A> Cont(Func<Input<E>, Iteratee<E, A>> c) =>
+      new Iteratee<E, A>(c.Right<Pair<A, Input<E>>, Func<Input<E>, Iteratee<E, A>>>());
 
-    public static Iteratee<E, A> Cont(Func<Input<E>, Iteratee<E, A>> c) {
-      return new Iteratee<E, A>(c.Right<Pair<A, Input<E>>, Func<Input<E>, Iteratee<E, A>>>());
-    }
-  }
+}
 
   public static class Iteratee {
-
-     
 
     public static Iteratee<A, Option<A>> Head<A>() {
         Func<Input<A>, Iteratee<A, Option<A>>> step = default(Func<Input<A>, Iteratee<A, Option<A>>>);
@@ -344,7 +224,7 @@ namespace XSharpx {
 
     public static Iteratee<E, A> Fold<E, A>(Func<A, E, A> f, A z) {
         Func<A, Input<E>, Iteratee<E, A>> step = default(Func<A, Input<E>, Iteratee<E, A>>);
-        step = (acc, i) => i.Fold<Iteratee<E, A>>(
+        step = (acc, i) => i.Fold(
           () => Iteratee<E, A>.Cont(j => step(acc, j))
         , () => Iteratee<E, A>.Done(acc, Input<E>.Eof())
         , e => Iteratee<E, A>.Cont(j => step(f(acc, e), j))
@@ -353,39 +233,32 @@ namespace XSharpx {
       return Iteratee<E, A>.Cont(i => step(z, i));
     }
 
-    public static Iteratee<A, A> Sum<A>(Monoid<A> m) {
-      return Fold(m.Op, m.Id);
-    }
+    public static Iteratee<A, A> Sum<A>(Monoid<A> m) => Fold(m.Op, m.Id);
 
   }
 
   public static class IterateeExtension {
-    public static Iteratee<E, B> Select<E, A, B>(this Iteratee<E, A> k, Func<A, B> f) {
-      return k.SelectMany<E, A, B>(a => Iteratee<E, B>.Done(f(a), Input<E>.Empty()));
-    }
+    public static Iteratee<E, B> Select<E, A, B>(this Iteratee<E, A> k, Func<A, B> f) =>
+      k.SelectMany(a => Iteratee<E, B>.Done(f(a), Input<E>.Empty()));
 
-    public static Iteratee<E, B> SelectMany<E, A, B>(this Iteratee<E, A> k, Func<A, Iteratee<E, B>> f) {
-      return k.Fold<Iteratee<E, B>>(
-         (a, i) => i.IsEmpty ?
-                     f(a) :
-                     f(a).Fold(
-                       (b, _) => Iteratee<E, B>.Done(b, i)
-                     , s => s(i)
-                     )
-       , r => Iteratee<E, B>.Cont(u => r(u).SelectMany(f))
+    public static Iteratee<E, B> SelectMany<E, A, B>(this Iteratee<E, A> k, Func<A, Iteratee<E, B>> f) =>
+      k.Fold(
+        (a, i) => i.IsEmpty ?
+                  f(a) :
+                  f(a).Fold(
+                    (b, _) => Iteratee<E, B>.Done(b, i)
+                    , s => s(i)
+                    )
+        , r => Iteratee<E, B>.Cont(u => r(u).SelectMany(f))
       );
-    }
 
-    public static Iteratee<E, C> SelectMany<E, A, B, C>(this Iteratee<E, A> k, Func<A, Iteratee<E, B>> p, Func<A, B, C> f) {
-      return SelectMany(k, a => Select(p(a), b => f(a, b)));
-    }
+    public static Iteratee<E, C> SelectMany<E, A, B, C>(this Iteratee<E, A> k, Func<A, Iteratee<E, B>> p, Func<A, B, C> f) =>
+      SelectMany(k, a => Select(p(a), b => f(a, b)));
 
-    public static Iteratee<E, B> Apply<E, A, B>(this Iteratee<E, Func<A, B>> f, Iteratee<E, A> o) {
-      return f.SelectMany(g => o.Select(p => g(p)));
-    }
+    public static Iteratee<E, B> Apply<E, A, B>(this Iteratee<E, Func<A, B>> f, Iteratee<E, A> o) =>
+      f.SelectMany(g => o.Select(p => g(p)));
 
-    public static Iteratee<E, A> Flatten<E, A>(this Iteratee<E, Iteratee<E, A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static Iteratee<E, A> Flatten<E, A>(this Iteratee<E, Iteratee<E, A>> o) => o.SelectMany(z => z);
+
   }
 }

--- a/src/XSharpx/List.cs
+++ b/src/XSharpx/List.cs
@@ -45,23 +45,11 @@ namespace XSharpx
       }
     }
 
-    public bool IsEmpty {
-      get {
-        return e;
-      }
-    }
+    public bool IsEmpty => e;
 
-    public bool IsNotEmpty {
-      get {
-        return !e;
-      }
-    }
+    public bool IsNotEmpty => !e;
 
-    public List<List<A>> Duplicate {
-      get {
-        return Extend(q => q);
-      }
-    }
+    public List<List<A>> Duplicate => Extend(q => q);
 
     public List<B> Extend<B>(Func<List<A>, B> f) {
       var b = ListBuffer<B>.Empty();
@@ -75,13 +63,11 @@ namespace XSharpx
       return b.ToList;
     }
 
-    public List<C> ProductWith<B, C>(List<B> o, Func<A, Func<B, C>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public List<C> ProductWith<B, C>(List<B> o, Func<A, Func<B, C>> f) =>
+      this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public List<Pair<A, B>> Product<B>(List<B> o) {
-      return ProductWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
-    }
+    public List<Pair<A, B>> Product<B>(List<B> o) =>
+      ProductWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
 
     public List<A> Append(List<A> x) {
       var b = ListBuffer<A>.Empty();
@@ -95,36 +81,21 @@ namespace XSharpx
       return b.ToList;
     }
 
-    public DiffList<A> ToDiffList {
-      get {
-        return DiffList<A>.diffList(r => this * r);
-      }
-    }
-    public NonEmptyList<A> Append(NonEmptyList<A> x) {
-      return IsEmpty ? x : new NonEmptyList<A>(UnsafeHead, UnsafeTail).Append(x);
-    }
+    public DiffList<A> ToDiffList => DiffList<A>.diffList(r => this * r);
 
-    public static List<A> operator +(A h, List<A> t) {
-      return Cons(h, t);
-    }
+    public NonEmptyList<A> Append(NonEmptyList<A> x) =>
+      IsEmpty ? x : new NonEmptyList<A>(UnsafeHead, UnsafeTail).Append(x);
 
-    public static NonEmptyList<A> operator &(A h, List<A> t) {
-      return new NonEmptyList<A>(h, t);
-    }
+    public static List<A> operator +(A h, List<A> t) =>
+      Cons(h, t);
 
-    public static List<A> operator *(List<A> a1, List<A> a2) {
-      return a1.Append(a2);
-    }
+    public static NonEmptyList<A> operator &(A h, List<A> t) => new NonEmptyList<A>(h, t);
 
-    public static List<A> Empty {
-      get {
-        return new List<A>(true, default(A), default(List<A>));
-      }
-    }
+    public static List<A> operator *(List<A> a1, List<A> a2) => a1.Append(a2);
 
-    public static List<A> Cons(A h, List<A> t) {
-      return new List<A>(false, h, t);
-    }
+    public static List<A> Empty => new List<A>(true, default(A), default(List<A>));
+
+    public static List<A> Cons(A h, List<A> t) => new List<A>(false, h, t);
 
     public static List<A> list(params A[] a) {
       var k = List<A>.Empty;
@@ -161,30 +132,17 @@ namespace XSharpx
         return !a.IsEmpty;
       }
 
-      A IEnumerator<A>.Current {
-        get {
-          return a.UnsafeHead;
-        }
-      }
+      A IEnumerator<A>.Current => a.UnsafeHead;
 
-      public object Current {
-        get {
-          return a.UnsafeHead;
-        }
-      }
+      public object Current => a.UnsafeHead;
+
     }
 
-    private ListEnumerator Enumerate() {
-      return new ListEnumerator(this);
-    }
+    private ListEnumerator Enumerate() => new ListEnumerator(this);
 
-    IEnumerator<A> IEnumerable<A>.GetEnumerator() {
-      return Enumerate();
-    }
+    IEnumerator<A> IEnumerable<A>.GetEnumerator() => Enumerate();
 
-    IEnumerator IEnumerable.GetEnumerator() {
-      return Enumerate();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => Enumerate();
 
     public ListBuffer<A> Buffer {
       get {
@@ -197,39 +155,21 @@ namespace XSharpx
       }
     }
 
-    public Option<A> Head {
-      get {
-        return IsEmpty ? Option.Empty : Option.Some(UnsafeHead);
-      }
-    }
+    public Option<A> Head => IsEmpty ? Option.Empty : Option.Some(UnsafeHead);
 
-    public Option<List<A>> Tail {
-      get {
-        return IsEmpty ? Option.Empty : Option.Some(UnsafeTail);
-      }
-    }
+    public Option<List<A>> Tail => IsEmpty ? Option.Empty : Option.Some(UnsafeTail);
 
-    public A HeadOr(Func<A> a) {
-      return IsEmpty ? a() : UnsafeHead;
-    }
+    public A HeadOr(Func<A> a) => IsEmpty ? a() : UnsafeHead;
 
-    public List<A> TailOr(Func<List<A>> a) {
-      return IsEmpty ? a() : UnsafeTail;
-    }
+    public List<A> TailOr(Func<List<A>> a) => IsEmpty ? a() : UnsafeTail;
 
-    public X Uncons<X>(Func<X> nil, Func<A, List<A>, X> headTail) {
-      return IsEmpty ? nil() : headTail(UnsafeHead, UnsafeTail);
-    }
+    public X Uncons<X>(Func<X> nil, Func<A, List<A>, X> headTail) => IsEmpty ? nil() : headTail(UnsafeHead, UnsafeTail);
 
-    public Option<Pair<A, List<A>>> HeadTail {
-      get {
-        return IsEmpty ? Option.Empty : Pair<A, List<A>>.pair(UnsafeHead, UnsafeTail).Some();
-      }
-    }
+    public Option<Pair<A, List<A>>> HeadTail =>
+      IsEmpty ? Option.Empty : Pair<A, List<A>>.pair(UnsafeHead, UnsafeTail).Some();
 
-    public B FoldRight<B>(Func<A, B, B> f, B b) {
-      return e ? b : f(UnsafeHead, UnsafeTail.FoldRight(f, b));
-    }
+    public B FoldRight<B>(Func<A, B, B> f, B b) =>
+      e ? b : f(UnsafeHead, UnsafeTail.FoldRight(f, b));
 
     public B FoldLeft<B>(Func<B, A, B> f, B b) {
       var x = b;
@@ -241,17 +181,11 @@ namespace XSharpx
       return x;
     }
 
-    public A SumRight(Monoid<A> m) {
-      return FoldRight<A>(m.Op, m.Id);
-    }
+    public A SumRight(Monoid<A> m) => FoldRight(m.Op, m.Id);
 
-    public A SumLeft(Monoid<A> m) {
-      return FoldLeft<A>(m.Op, m.Id);
-    }
+    public A SumLeft(Monoid<A> m) => FoldLeft(m.Op, m.Id);
 
-    public B SumMapRight<B>(Func<A, B> f, Monoid<B> m) {
-      return FoldRight<B>((a, b) => m.Op(f(a), b), m.Id);
-    }
+    public B SumMapRight<B>(Func<A, B> f, Monoid<B> m) => FoldRight((a, b) => m.Op(f(a), b), m.Id);
 
     public B SumMapLeft<B>(Func<A, B> f, Monoid<B> m) {
       return FoldLeft<B>((a, b) => m.Op(a, f(b)), m.Id);
@@ -273,27 +207,24 @@ namespace XSharpx
       return b.ToList;
     }
 
-    public List<A> Take(int n) {
-      return n <= 0 || e
+    public List<A> Take(int n) =>
+      n <= 0 || e
         ? List<A>.Empty
         : UnsafeHead + UnsafeTail.Take(n - 1);
-    }
 
-    public List<A> Drop(int n) {
-      return n <= 0
+    public List<A> Drop(int n) =>
+      n <= 0
         ? this
         : e
           ? List<A>.Empty
           : UnsafeTail.Drop(n - 1);
-    }
 
-    public List<A> TakeWhile(Func<A, bool> p) {
-      return e
+    public List<A> TakeWhile(Func<A, bool> p) =>
+      e
         ? this
         : p(UnsafeHead)
           ? UnsafeHead + UnsafeTail.TakeWhile(p)
           : List<A>.Empty;
-    }
 
     public List<A> DropWhile(Func<A, bool> p) {
       var a = this;
@@ -305,37 +236,25 @@ namespace XSharpx
       return a;
     }
 
-    public int Length {
-      get {
-        return FoldLeft((b, _) => b + 1, 0);
-      }
-    }
+    public int Length =>FoldLeft((b, _) => b + 1, 0);
 
-    public List<A> Reverse {
-      get {
-        return FoldLeft<List<A>>((b, a) => a + b, List<A>.Empty);
-      }
-    }
+    public List<A> Reverse => FoldLeft<List<A>>((b, a) => a + b, List<A>.Empty);
+    public Option<A> this [int n] =>
+      n < 0 || IsEmpty
+        ? Option.Empty
+        : n == 0
+          ? Option.Some(UnsafeHead)
+          : UnsafeTail[n - 1];
+      
 
-    public Option<A> this [int n] {
-      get {
-        return n < 0 || IsEmpty
-          ? Option.Empty
-          : n == 0
-            ? Option.Some(UnsafeHead)
-            : UnsafeTail[n - 1];
-      }
-    }
-
-    public List<C> ZipWith<B, C>(List<B> bs, Func<A, Func<B, C>> f) {
-      return IsEmpty && bs.IsEmpty
+    public List<C> ZipWith<B, C>(List<B> bs, Func<A, Func<B, C>> f) =>
+      IsEmpty && bs.IsEmpty
         ? List<C>.Empty
         : f(UnsafeHead)(bs.UnsafeHead) + UnsafeTail.ZipWith(bs.UnsafeTail, f);
-    }
 
-    public List<Pair<A, B>> Zip<B>(List<B> bs) {
-      return ZipWith<B, Pair<A, B>>(bs, a => b => Pair<A, B>.pair(a, b));
-    }
+
+    public List<Pair<A, B>> Zip<B>(List<B> bs) =>
+      ZipWith<B, Pair<A, B>>(bs, a => b => Pair<A, B>.pair(a, b));
 
     public bool All(Func<A, bool> f) {
       var x = true;
@@ -359,71 +278,59 @@ namespace XSharpx
       return x;
     }
 
-    public List<List<B>> TraverseList<B>(Func<A, List<B>> f) {
-      return FoldRight<List<List<B>>>(
+    public List<List<B>> TraverseList<B>(Func<A, List<B>> f) =>
+      FoldRight(
         (a, b) => f(a).ProductWith<List<B>, List<B>>(b, aa => bb => aa + bb)
       , List<B>.Empty.ListValue()
       );
-    }
 
-    public Option<List<B>> TraverseOption<B>(Func<A, Option<B>> f) {
-      return FoldRight<Option<List<B>>>(
+    public Option<List<B>> TraverseOption<B>(Func<A, Option<B>> f) =>
+      FoldRight(
         (a, b) => f(a).ZipWith<List<B>, List<B>>(b, aa => bb => aa + bb)
       , List<B>.Empty.Some()
       );
-    }
 
-    public Terminal<List<B>> TraverseTerminal<B>(Func<A, Terminal<B>> f) {
-      return FoldRight<Terminal<List<B>>>(
+    public Terminal<List<B>> TraverseTerminal<B>(Func<A, Terminal<B>> f) =>
+      FoldRight(
         (a, b) => f(a).ZipWith<List<B>, List<B>>(b, aa => bb => aa + bb)
       , List<B>.Empty.TerminalValue()
       );
-    }
 
-    public Input<List<B>> TraverseInput<B>(Func<A, Input<B>> f) {
-      return FoldRight<Input<List<B>>>(
+    public Input<List<B>> TraverseInput<B>(Func<A, Input<B>> f) =>
+      FoldRight(
         (a, b) => f(a).ZipWith<List<B>, List<B>>(b, aa => bb => aa + bb)
       , List<B>.Empty.InputElement()
       );
-    }
 
-    public Either<X, List<B>> TraverseEither<X, B>(Func<A, Either<X, B>> f) {
-      return FoldRight<Either<X, List<B>>>(
+    public Either<X, List<B>> TraverseEither<X, B>(Func<A, Either<X, B>> f) =>
+      FoldRight<Either<X, List<B>>>(
         (a, b) => f(a).ZipWith<List<B>, List<B>>(b, aa => bb => aa + bb)
       , List<B>.Empty.Right<X, List<B>>()
       );
-    }
 
-    public NonEmptyList<List<B>> TraverseNonEmptyList<B>(Func<A, NonEmptyList<B>> f) {
-      return FoldRight<NonEmptyList<List<B>>>(
+    public NonEmptyList<List<B>> TraverseNonEmptyList<B>(Func<A, NonEmptyList<B>> f) =>
+      FoldRight(
         (a, b) => f(a).ProductWith<List<B>, List<B>>(b, aa => bb => aa + bb)
       , List<B>.Empty.NonEmptyListValue()
       );
-    }
 
-    public Pair<X, List<B>> TraversePair<X, B>(Func<A, Pair<X, B>> f, Monoid<X> m) {
-      return FoldRight<Pair<X, List<B>>>(
+
+    public Pair<X, List<B>> TraversePair<X, B>(Func<A, Pair<X, B>> f, Monoid<X> m) =>
+      FoldRight(
         (a, b) => f(a).Constrain(m).ZipWith<List<B>, List<B>>(b.Constrain(m), aa => bb => aa + bb).Pair
       , m.Id.And(List<B>.Empty)
       );
-    }
 
-    public Func<X, List<B>> TraverseFunc<X, B>(Func<A, Func<X, B>> f) {
-      return x => this.Select(a => f(a)(x));
-    }
+    public Func<X, List<B>> TraverseFunc<X, B>(Func<A, Func<X, B>> f) => x => this.Select(a => f(a)(x));
 
-    public Tree<List<B>> TraverseTree<B>(Func<A, Tree<B>> f) {
-      return FoldRight<Tree<List<B>>>(
+    public Tree<List<B>> TraverseTree<B>(Func<A, Tree<B>> f) =>
+      FoldRight(
         (a, b) => f(a).ZipWith<List<B>, List<B>>(b, aa => bb => aa + bb)
       , List<B>.Empty.TreeValue()
       );
-    }
 
-    public Option<ListZipper<A>> Zipper {
-      get {
-        return IsEmpty ? Option<ListZipper<A>>.Empty : (new ListZipper<A>(List<A>.Empty, UnsafeHead, UnsafeTail)).Some();
-      }
-    }
+    public Option<ListZipper<A>> Zipper =>
+      IsEmpty ? Option<ListZipper<A>>.Empty : (new ListZipper<A>(List<A>.Empty, UnsafeHead, UnsafeTail)).Some();
   }
 
   public static class ListExtension {
@@ -445,36 +352,31 @@ namespace XSharpx
       return b.ToList;
     }
 
-    public static List<C> SelectMany<A, B, C>(this List<A> ps, Func<A, List<B>> p, Func<A, B, C> f) {
-      return SelectMany(ps, a => Select(p(a), b => f(a, b)));
-    }
+    public static List<C> SelectMany<A, B, C>(this List<A> ps, Func<A, List<B>> p, Func<A, B, C> f) =>
+      SelectMany(ps, a => Select(p(a), b => f(a, b)));
+    
 
-    public static List<B> Apply<A, B>(this List<Func<A, B>> f, List<A> o) {
-      return f.ProductWith<A, B>(o, a => b => a(b));
-    }
+    public static List<B> Apply<A, B>(this List<Func<A, B>> f, List<A> o) =>
+      f.ProductWith<A, B>(o, a => b => a(b));
 
-    public static List<B> ApplyZip<A, B>(this List<Func<A, B>> f, List<A> o) {
-      return f.ZipWith<A, B>(o, a => b => a(b));
-    }
+    public static List<B> ApplyZip<A, B>(this List<Func<A, B>> f, List<A> o) =>
+      f.ZipWith<A, B>(o, a => b => a(b));
 
-    public static List<A> Flatten<A>(this List<List<A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static List<A> Flatten<A>(this List<List<A>> o) =>
+      o.SelectMany(z => z);
 
-    public static Pair<List<A>, List<B>> Unzip<A, B>(this List<Pair<A, B>> p) {
-      return p.FoldRight<Pair<List<A>, List<B>>>(
+    public static Pair<List<A>, List<B>> Unzip<A, B>(this List<Pair<A, B>> p) =>
+      p.FoldRight(
         (x, y) => (x._1.Get + y._1.Get).And(x._2.Get + y._2.Get)
       , List<A>.Empty.And(List<B>.Empty)
       );
-    }
 
-    public static List<A> ListValue<A>(this A a) {
-      return List<A>.Cons(a, List<A>.Empty);
-    }
+    public static List<A> ListValue<A>(this A a) =>
+      List<A>.Cons(a, List<A>.Empty);
 
-    public static List<B> UnfoldList<A, B>(this A a, Func<A, Option<Pair<B, A>>> f) {
-      return f(a).Fold<List<B>>(p => p._1.Get + p._2.Get.UnfoldList(f), () => List<B>.Empty);
-    }
+    public static List<B> UnfoldList<A, B>(this A a, Func<A, Option<Pair<B, A>>> f) =>
+      f(a).Fold(p => p._1.Get + p._2.Get.UnfoldList(f), () => List<B>.Empty);
+
   }
 }
 

--- a/src/XSharpx/ListBuffer.cs
+++ b/src/XSharpx/ListBuffer.cs
@@ -61,9 +61,7 @@ namespace XSharpx
       }
     }
 
-    public static ListBuffer<A> Empty() {
-      return new ListBuffer<A>();
-    }
+    public static ListBuffer<A> Empty() => new ListBuffer<A>();
 
     private class ListBufferEnumerator : IEnumerator<A> {
       private bool z = true;
@@ -90,30 +88,18 @@ namespace XSharpx
         return !a.IsEmpty;
       }
 
-      A IEnumerator<A>.Current {
-        get {
-          return a.UnsafeHead;
-        }
-      }
+      A IEnumerator<A>.Current => a.UnsafeHead;
 
-      public object Current {
-        get {
-          return a.UnsafeHead;
-        }
-      }
+      public object Current => a.UnsafeHead;
+
     }
 
-    private ListBufferEnumerator Enumerate() {
-      return new ListBufferEnumerator(this);
-    }
+    private ListBufferEnumerator Enumerate() => new ListBufferEnumerator(this);
 
-    IEnumerator<A> IEnumerable<A>.GetEnumerator() {
-      return Enumerate();
-    }
+    IEnumerator<A> IEnumerable<A>.GetEnumerator() => Enumerate();
 
-    IEnumerator IEnumerable.GetEnumerator() {
-      return Enumerate();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => Enumerate();
+
   }
 }
 

--- a/src/XSharpx/ListZipper.cs
+++ b/src/XSharpx/ListZipper.cs
@@ -34,11 +34,7 @@ namespace XSharpx {
       }
     }
 
-    public List<A> ToList {
-      get {
-        return lefts.Reverse * (focus + rights);
-      }
-    }
+    public List<A> ToList => lefts.Reverse * (focus + rights);
 
     public NonEmptyList<A> ToNonEmptyList {
       get {
@@ -47,29 +43,20 @@ namespace XSharpx {
       }
     }
 
-    public ListZipper<B> Select<B>(Func<A, B> f) {
-      return new ListZipper<B>(lefts.Select(f), f(focus), rights.Select(f));
-    }
+    public ListZipper<B> Select<B>(Func<A, B> f) =>
+      new ListZipper<B>(lefts.Select(f), f(focus), rights.Select(f));
 
-    public ListZipper<ListZipper<A>> Duplicate {
-      get {
-        return Extend(q => q);
-      }
-    }
-
+    public ListZipper<ListZipper<A>> Duplicate => Extend(q => q);
     public ListZipper<B> Extend<B>(Func<ListZipper<A>, B> f) {
       var l = this.UnfoldList(z => z.MoveLeft.Select(x => f(x).And(x)));
       var r = this.UnfoldList(z => z.MoveRight.Select(x => f(x).And(x)));
       return new ListZipper<B>(l, f(this), r);
     }
 
-    public ListZipper<A> Update(Func<A, A> f) {
-      return new ListZipper<A>(lefts, f(focus), rights);
-    }
+    public ListZipper<A> Update(Func<A, A> f) =>
+      new ListZipper<A>(lefts, f(focus), rights);
 
-    public ListZipper<A> Set(A a) {
-      return Update(_ => a);
-    }
+    public ListZipper<A> Set(A a) => Update(_ => a);
 
     public Option<ListZipper<A>> MoveLeft {
       get {
@@ -85,13 +72,9 @@ namespace XSharpx {
       }
     }
 
-    public ListZipper<A> MoveLeftOr(Func<ListZipper<A>> z) {
-      return MoveLeft.ValueOr(z);
-    }
+    public ListZipper<A> MoveLeftOr(Func<ListZipper<A>> z) => MoveLeft.ValueOr(z);
 
-    public ListZipper<A> MoveRightOr(Func<ListZipper<A>> z) {
-      return MoveRight.ValueOr(z);
-    }
+    public ListZipper<A> MoveRightOr(Func<ListZipper<A>> z) => MoveRight.ValueOr(z);
 
     public ListZipper<A> TryLeft {
       get {
@@ -107,31 +90,16 @@ namespace XSharpx {
       }
     }
 
-    public ListZipper<A> InsertLeft(A a) {
-      return new ListZipper<A>(lefts, a, focus + rights);
-    }
+    public ListZipper<A> InsertLeft(A a) => new ListZipper<A>(lefts, a, focus + rights);
 
-    public ListZipper<A> InsertRight(A a) {
-      return new ListZipper<A>(focus + lefts, a, rights);
-    }
+    public ListZipper<A> InsertRight(A a) => new ListZipper<A>(focus + lefts, a, rights);
 
-    public ListZipper<A> DeleteOthers {
-      get {
-        return new ListZipper<A>(List<A>.Empty, focus, List<A>.Empty);
-      }
-    }
+    public ListZipper<A> DeleteOthers =>
+      new ListZipper<A>(List<A>.Empty, focus, List<A>.Empty);
 
-    public ListZipper<A> DeleteLefts {
-      get {
-        return new ListZipper<A>(List<A>.Empty, focus, rights);
-      }
-    }
+    public ListZipper<A> DeleteLefts => new ListZipper<A>(List<A>.Empty, focus, rights);
 
-    public ListZipper<A> DeleteRights {
-      get {
-        return new ListZipper<A>(lefts, focus, List<A>.Empty);
-      }
-    }
+    public ListZipper<A> DeleteRights => new ListZipper<A>(lefts, focus, List<A>.Empty);
 
     public Option<ListZipper<A>> DeletePullLeft {
       get {
@@ -147,13 +115,9 @@ namespace XSharpx {
       }
     }
 
-    public ListZipper<A> DeletePullLeftOr(Func<ListZipper<A>> z) {
-      return DeletePullLeft.ValueOr(z);
-    }
+    public ListZipper<A> DeletePullLeftOr(Func<ListZipper<A>> z) => DeletePullLeft.ValueOr(z);
 
-    public ListZipper<A> DeletePullRightOr(Func<ListZipper<A>> z) {
-      return DeletePullRight.ValueOr(z);
-    }
+    public ListZipper<A> DeletePullRightOr(Func<ListZipper<A>> z) => DeletePullRight.ValueOr(z);
 
     public ListZipper<A> TryDeletePullLeft {
       get {
@@ -169,17 +133,9 @@ namespace XSharpx {
       }
     }
 
-    public bool IsStart {
-      get {
-        return lefts.IsEmpty;
-      }
-    }
+    public bool IsStart => lefts.IsEmpty;
 
-    public bool IsEnd {
-      get {
-        return rights.IsEmpty;
-      }
-    }
+    public bool IsEnd => rights.IsEmpty;
 
     public Option<ListZipper<A>> FindLeft(Func<A, bool> p) {
       var z = MoveLeft;
@@ -201,13 +157,11 @@ namespace XSharpx {
       return z;
     }
 
-    public ListZipper<A> FindLeftOr(Func<A, bool> p, Func<ListZipper<A>> z) {
-      return FindLeft(p).ValueOr(z);
-    }
+    public ListZipper<A> FindLeftOr(Func<A, bool> p, Func<ListZipper<A>> z) =>
+      FindLeft(p).ValueOr(z);
 
-    public ListZipper<A> FindRightOr(Func<A, bool> p, Func<ListZipper<A>> z) {
-      return FindRight(p).ValueOr(z);
-    }
+    public ListZipper<A> FindRightOr(Func<A, bool> p, Func<ListZipper<A>> z) =>
+      FindRight(p).ValueOr(z);
 
     public ListZipper<A> TryFindLeft(Func<A, bool> p) {
       var t = this;
@@ -219,21 +173,19 @@ namespace XSharpx {
       return FindRightOr(p, () => t);
     }
 
-    public Option<ListZipper<A>> MoveLeftN(int n) {
-      return n == 0 ?
-               this.Some() :
-               n < 0 ?
-               MoveRightN(Math.Abs(n)) :
-               MoveLeft.SelectMany(z => z.MoveLeftN(n - 1));
-    }
-
-    public Option<ListZipper<A>> MoveRightN(int n) {
-      return n == 0 ?
+    public Option<ListZipper<A>> MoveLeftN(int n) =>
+      n == 0 ?
         this.Some() :
         n < 0 ?
-        MoveLeftN(Math.Abs(n)) :
-        MoveRight.SelectMany(z => z.MoveRightN(n - 1));
-    }
+          MoveRightN(Math.Abs(n)) :
+          MoveLeft.SelectMany(z => z.MoveLeftN(n - 1));
+
+    public Option<ListZipper<A>> MoveRightN(int n) =>
+      n == 0 ?
+        this.Some() :
+        n < 0 ?
+          MoveLeftN(Math.Abs(n)) :
+          MoveRight.SelectMany(z => z.MoveRightN(n - 1));
 
     public ListZipper<A> Start {
       get {
@@ -341,19 +293,16 @@ namespace XSharpx {
         select new ListZipper<B>(ll, xx, rr);
     }
 
-    public static ListZipper<A> operator %(ListZipper<A> z, Func<A, A> f) {
-      return z.Update(f);
-    }
+    public static ListZipper<A> operator %(ListZipper<A> z, Func<A, A> f) => z.Update(f);
+    
   }
 
   public static class ListZipperExtension {
 
-    public static Pair<ListZipper<A>, ListZipper<B>> Unzip<A, B>(this ListZipper<Pair<A, B>> p) {
-      return p.Select(q => q._1.Get).And(p.Select(q => q._2.Get));
-    }
+    public static Pair<ListZipper<A>, ListZipper<B>> Unzip<A, B>(this ListZipper<Pair<A, B>> p) =>
+      p.Select(q => q._1.Get).And(p.Select(q => q._2.Get));
 
-    public static ListZipper<A> ListZipperValue<A>(this A a) {
-      return new ListZipper<A>(List<A>.Empty, a, List<A>.Empty);
-    }
+    public static ListZipper<A> ListZipperValue<A>(this A a) =>
+      new ListZipper<A>(List<A>.Empty, a, List<A>.Empty);
   }
 }

--- a/src/XSharpx/Monoid.cs
+++ b/src/XSharpx/Monoid.cs
@@ -1,205 +1,109 @@
 using System;
 
-namespace XSharpx {
-  public struct Monoid<A> {
-    private readonly Func<A, A, A> op;
-    private readonly A id;
+namespace XSharpx
+{
+    public struct Monoid<A>
+    {
+        private readonly Func<A, A, A> op;
+        private readonly A id;
 
-    private Monoid(Func<A, A, A> op, A id) {
-      this.op = op;
-      this.id = id;
-    }
-
-    public Semigroup<A> Semigroup {
-      get {
-        return Semigroup<A>.semigroup(op);
-      }
-    }
-
-    public Func<A, A, A> Op {
-      get {
-        return op;
-      }
-    }
-
-    public A Id {
-      get {
-        return id;
-      }
-    }
-
-    public A Apply(A a1, A a2) {
-      return Semigroup.Apply(a1, a2);
-    }
-
-    public Func<A, Func<A, A>> Curried {
-      get {
-        return Semigroup.Curried;
-      }
-    }
-
-    public Func<A, A> Curried1(A a1) {
-      return Semigroup.Curried1(a1);
-    }
-
-    public Monoid<A> Dual {
-      get {
-        return Semigroup.Dual.Monoid(id);
-      }
-    }
-
-    public Func<A, A> Join {
-      get {
-        return Semigroup.Join;
-      }
-    }
-
-    public Monoid<Pair<A, B>> Pair<B>(Monoid<B> s) {
-      return Semigroup.Pair(s.Semigroup).Monoid(id.And(s.Id));
-    }
-
-    public Monoid<Option<A>> Option {
-      get {
-        return Semigroup.Option.Monoid(Option<A>.Empty);
-      }
-    }
-
-    public Monoid<Input<A>> Input {
-      get {
-        return Semigroup.Input.Monoid(Input<A>.Empty());
-      }
-    }
-
-    public Monoid<Func<B, A>> Pointwise<B>() {
-      var t = this;
-      return Semigroup.Pointwise<B>().Monoid(_ => t.id);
-    }
-
-    public Monoid<Func<B, C, A>> Pointwise2<B, C>() {
-      var t = this;
-      return Semigroup.Pointwise2<B, C>().Monoid((_, __) => t.id);
-    }
-
-    public Monoid<Func<B, C, D, A>> Pointwise3<B, C, D>() {
-      var t = this;
-      return Semigroup.Pointwise3<B, C, D>().Monoid((_, __, ___) => t.id);
-    }
-
-    public Monoid<B> XSelect<B>(Func<A, B> f, Func<B, A> g) {
-      return Semigroup.XSelect(f, g).Monoid(f(id));
-    }
-
-    public static Monoid<A> monoid(Func<A, A, A> op, A id) {
-      return new Monoid<A>(op, id);
-    }
-
-    public static Monoid<Option<A>> FirstOption {
-      get {
-        return Semigroup<A>.FirstOption.Monoid(Option<A>.Empty);
-      }
-    }
-
-    public static Monoid<Option<A>> SecondOption {
-      get {
-        return Semigroup<A>.SecondOption.Monoid(Option<A>.Empty);
-      }
-    }
-
-    public static Monoid<Func<A, A>> Endo {
-      get {
-        return Semigroup<A>.Endo.Monoid(a => a);
-      }
-    }
-
-    public static Monoid<List<A>> List {
-      get {
-        return Semigroup<A>.List.Monoid(List<A>.Empty);
-      }
-    }
-  }
-
-  public static class Monoid {
-    public static Monoid<bool> Or {
-      get {
-        return Semigroup.Or.Monoid(false);
-      }
-    }
-
-    public static Monoid<bool> And {
-      get {
-        return Semigroup.And.Monoid(true);
-      }
-    }
-
-    public static Monoid<string> String {
-      get {
-        return Semigroup.String.Monoid("");
-      }
-    }
-
-    public static class Sum {
-      public static Monoid<int> Integer {
-        get {
-          return Semigroup.Sum.Integer.Monoid(0);
+        private Monoid(Func<A, A, A> op, A id)
+        {
+            this.op = op;
+            this.id = id;
         }
-      }
 
-      public static Monoid<byte> Byte {
-        get {
-          return Semigroup.Sum.Byte.Monoid(0);
-        }
-      }
+        public Semigroup<A> Semigroup => Semigroup<A>.semigroup(op);
 
-      public static Monoid<short> Short {
-        get {
-          return Semigroup.Sum.Short.Monoid(0);
-        }
-      }
+        public Func<A, A, A> Op => op;
 
-      public static Monoid<long> Long {
-        get {
-          return Semigroup.Sum.Long.Monoid(0);
-        }
-      }
+        public A Id => id;
 
-      public static Monoid<char> Char {
-        get {
-          return Semigroup.Sum.Char.Monoid((char)0);
+        public A Apply(A a1, A a2) => Semigroup.Apply(a1, a2);
+
+        public Func<A, Func<A, A>> Curried => Semigroup.Curried;
+
+        public Func<A, A> Curried1(A a1) => Semigroup.Curried1(a1);
+
+        public Monoid<A> Dual => Semigroup.Dual.Monoid(id);
+
+        public Func<A, A> Join => Semigroup.Join;
+
+        public Monoid<Pair<A, B>> Pair<B>(Monoid<B> s) => Semigroup.Pair(s.Semigroup).Monoid(id.And(s.Id));
+
+        public Monoid<Option<A>> Option => Semigroup.Option.Monoid(Option<A>.Empty);
+
+        public Monoid<Input<A>> Input => Semigroup.Input.Monoid(Input<A>.Empty());
+
+        public Monoid<Func<B, A>> Pointwise<B>()
+        {
+            var t = this;
+            return Semigroup.Pointwise<B>().Monoid(_ => t.id);
         }
-      }
+
+        public Monoid<Func<B, C, A>> Pointwise2<B, C>()
+        {
+            var t = this;
+            return Semigroup.Pointwise2<B, C>().Monoid((_, __) => t.id);
+        }
+
+        public Monoid<Func<B, C, D, A>> Pointwise3<B, C, D>()
+        {
+            var t = this;
+            return Semigroup.Pointwise3<B, C, D>().Monoid((_, __, ___) => t.id);
+        }
+
+        public Monoid<B> XSelect<B>(Func<A, B> f, Func<B, A> g)
+        {
+            return Semigroup.XSelect(f, g).Monoid(f(id));
+        }
+
+        public static Monoid<A> monoid(Func<A, A, A> op, A id) => new Monoid<A>(op, id);
+
+        public static Monoid<Option<A>> FirstOption => Semigroup<A>.FirstOption.Monoid(Option<A>.Empty);
+
+        public static Monoid<Option<A>> SecondOption => Semigroup<A>.SecondOption.Monoid(Option<A>.Empty);
+
+        public static Monoid<Func<A, A>> Endo => Semigroup<A>.Endo.Monoid(a => a);
+
+        public static Monoid<List<A>> List => Semigroup<A>.List.Monoid(List<A>.Empty);
+
     }
 
-    public static class Product {
-      public static Monoid<int> Integer {
-        get {
-          return Semigroup.Product.Integer.Monoid(1);
-        }
-      }
+    public static class Monoid
+    {
+        public static Monoid<bool> Or => Semigroup.Or.Monoid(false);
 
-      public static Monoid<byte> Byte {
-        get {
-          return Semigroup.Product.Byte.Monoid(1);
-        }
-      }
+        public static Monoid<bool> And => Semigroup.And.Monoid(true);
 
-      public static Monoid<short> Short {
-        get {
-          return Semigroup.Product.Short.Monoid(1);
-        }
-      }
+        public static Monoid<string> String => Semigroup.String.Monoid("");
 
-      public static Monoid<long> Long {
-        get {
-          return Semigroup.Product.Long.Monoid(1);
-        }
-      }
+        public static class Sum
+        {
+            public static Monoid<int> Integer => Semigroup.Sum.Integer.Monoid(0);
 
-      public static Monoid<char> Char {
-        get {
-          return Semigroup.Product.Char.Monoid((char)1);
+            public static Monoid<byte> Byte => Semigroup.Sum.Byte.Monoid(0);
+
+            public static Monoid<short> Short => Semigroup.Sum.Short.Monoid(0);
+
+            public static Monoid<long> Long => Semigroup.Sum.Long.Monoid(0);
+            public static Monoid<char> Char => Semigroup.Sum.Char.Monoid((char)0);
+
         }
-      }
+
+        public static class Product
+        {
+            public static Monoid<int> Integer => Semigroup.Product.Integer.Monoid(1);
+
+            public static Monoid<byte> Byte => Semigroup.Product.Byte.Monoid(1);
+
+            public static Monoid<short> Short => Semigroup.Product.Short.Monoid(1);
+
+            public static Monoid<long> Long => Semigroup.Product.Long.Monoid(1);
+
+            public static Monoid<char> Char => Semigroup.Product.Char.Monoid((char)1);
+
+        }
     }
-  }
 }
 

--- a/src/XSharpx/NonEmptyList.cs
+++ b/src/XSharpx/NonEmptyList.cs
@@ -26,29 +26,18 @@ namespace XSharpx {
       }
     }
 
-    public List<A> List {
-      get {
-        return head + tail;
-      }
-    }
+    public List<A> List => head + tail;
 
-    public NonEmptyList<B> Select<B>(Func<A, B> f) {
-      return new NonEmptyList<B>(f(head), tail.Select(f));
-    }
+    public NonEmptyList<B> Select<B>(Func<A, B> f) =>
+      new NonEmptyList<B>(f(head), tail.Select(f));
 
-    public NonEmptyList<B> SelectMany<B>(Func<A, NonEmptyList<B>> f) {
-      return f(head).Append(tail.SelectMany(a => f(a).List));
-    }
+    public NonEmptyList<B> SelectMany<B>(Func<A, NonEmptyList<B>> f) =>
+      f(head).Append(tail.SelectMany(a => f(a).List));
 
-    public NonEmptyList<C> SelectMany<B, C>(Func<A, NonEmptyList<B>> p, Func<A, B, C> f) {
-      return SelectMany<C>(a => p(a).Select<C>(b => f(a, b)));
-    }
+    public NonEmptyList<C> SelectMany<B, C>(Func<A, NonEmptyList<B>> p, Func<A, B, C> f) =>
+      SelectMany<C>(a => p(a).Select<C>(b => f(a, b)));
 
-    public NonEmptyList<NonEmptyList<A>> Duplicate {
-      get {
-        return Extend(q => q);
-      }
-    }
+    public NonEmptyList<NonEmptyList<A>> Duplicate => Extend(q => q);
 
     public NonEmptyList<B> Extend<B>(Func<NonEmptyList<A>, B> f) {
       var b = ListBuffer<B>.Empty();
@@ -62,73 +51,45 @@ namespace XSharpx {
       return new NonEmptyList<B>(f(this), b.ToList);
     }
 
-    public NonEmptyList<C> ProductWith<B, C>(NonEmptyList<B> o, Func<A, Func<B, C>> f) {
-      return SelectMany<C>(a => o.Select<C>(b => f(a)(b)));
-    }
+    public NonEmptyList<C> ProductWith<B, C>(NonEmptyList<B> o, Func<A, Func<B, C>> f) =>
+      SelectMany<C>(a => o.Select<C>(b => f(a)(b)));
+    
+    public NonEmptyList<Pair<A, B>> Product<B>(NonEmptyList<B> o) =>
+      ZipWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
 
-    public NonEmptyList<Pair<A, B>> Product<B>(NonEmptyList<B> o) {
-      return ZipWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
-    }
+    public NonEmptyList<A> Append(List<A> x) =>
+      new NonEmptyList<A>(head, tail.Append(x));
 
-    public NonEmptyList<A> Append(List<A> x) {
-      return new NonEmptyList<A>(head, tail.Append(x));
-    }
+    public NonEmptyList<A> Append(NonEmptyList<A> x) => Append(x.List);
 
-    public NonEmptyList<A> Append(NonEmptyList<A> x) {
-      return Append(x.List);
-    }
+    public static NonEmptyList<A> operator +(List<A> s, NonEmptyList<A> t) => s.Append(t);
 
-    public static NonEmptyList<A> operator +(List<A> s, NonEmptyList<A> t) {
-      return s.Append(t);
-    }
+    public static NonEmptyList<A> operator &(A h, NonEmptyList<A> t) => new NonEmptyList<A>(h, t.List);
 
-    public static NonEmptyList<A> operator &(A h, NonEmptyList<A> t) {
-      return new NonEmptyList<A>(h, t.List);
-    }
+    public static NonEmptyList<A> operator *(NonEmptyList<A> a1, NonEmptyList<A> a2) => a1.Append(a2);
 
-    public static NonEmptyList<A> operator *(NonEmptyList<A> a1, NonEmptyList<A> a2) {
-      return a1.Append(a2);
-    }
+    public static NonEmptyList<A> nel(A h, params A[] a) => new NonEmptyList<A>(h, List<A>.list(a));
 
-    public static NonEmptyList<A> nel(A h, params A[] a) {
-      return new NonEmptyList<A>(h, List<A>.list(a));
-    }
+    IEnumerator<A> IEnumerable<A>.GetEnumerator() => ((IEnumerable<A>)List).GetEnumerator();
 
-    IEnumerator<A> IEnumerable<A>.GetEnumerator() {
-      return ((IEnumerable<A>)List).GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)List).GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() {
-      return ((IEnumerable)List).GetEnumerator();
-    }
+    public X Uncons<X>(Func<A, List<A>, X> headTail) => headTail(head, tail);
 
-    public X Uncons<X>(Func<A, List<A>, X> headTail) {
-      return headTail(head, tail);
-    }
+    public B FoldRight<B>(Func<A, B, B> f, B b) => List.FoldRight(f, b);
 
-    public B FoldRight<B>(Func<A, B, B> f, B b) {
-      return List.FoldRight(f, b);
-    }
+    public B FoldLeft<B>(Func<B, A, B> f, B b) => List.FoldLeft (f, b);
 
-    public B FoldLeft<B>(Func<B, A, B> f, B b) {
-      return List.FoldLeft (f, b);
-    }
+    public A SumRight(Semigroup<A> m) => tail.FoldRight<A>(m.Op, head);
 
-    public A SumRight(Semigroup<A> m) {
-      return tail.FoldRight<A>(m.Op, head);
-    }
+    public A SumLeft(Semigroup<A> m) => tail.FoldLeft<A>(m.Op, head);
 
-    public A SumLeft(Semigroup<A> m) {
-      return tail.FoldLeft<A>(m.Op, head);
-    }
+    public B SumMapRight<B>(Func<A, B> f, Semigroup<B> m) =>
+      tail.FoldRight<B>((a, b) => m.Op(f(a), b), f(head));
+    
 
-    public B SumMapRight<B>(Func<A, B> f, Semigroup<B> m) {
-      return tail.FoldRight<B>((a, b) => m.Op(f(a), b), f(head));
-    }
-
-    public B SumMapLeft<B>(Func<A, B> f, Semigroup<B> m) {
-      return tail.FoldLeft<B>((a, b) => m.Op(a, f(b)), f(head));
-    }
+    public B SumMapLeft<B>(Func<A, B> f, Semigroup<B> m) =>
+      tail.FoldLeft<B>((a, b) => m.Op(a, f(b)), f(head));
 
     public void ForEach(Action<A> a) {
       foreach(A x in this) {
@@ -136,136 +97,85 @@ namespace XSharpx {
       }
     }
 
-    public List<A> Where(Func<A, bool> f) {
-      return List.Where(f);
-    }
+    public List<A> Where(Func<A, bool> f) => List.Where(f);
 
-    public List<A> Take(int n) {
-      return List.Take(n);
-    }
+    public List<A> Take(int n) => List.Take(n);
 
-    public List<A> Drop(int n) {
-      return List.Drop(n);
-    }
+    public List<A> Drop(int n) => List.Drop(n);
 
-    public List<A> TakeWhile(Func<A, bool> p) {
-      return List.TakeWhile(p);
-    }
+    public List<A> TakeWhile(Func<A, bool> p) => List.TakeWhile(p);
 
-    public List<A> DropWhile(Func<A, bool> p) {
-      return List.DropWhile(p);
-    }
 
-    public int Length {
-      get {
-        return 1 + tail.Length;
-      }
-    }
+    public List<A> DropWhile(Func<A, bool> p) => List.DropWhile(p);
+    public int Length => 1 + tail.Length;
 
-    public NonEmptyList<A> Reverse {
-      get {
-        return FoldLeft<NonEmptyList<A>>((b, a) => a & b, new NonEmptyList<A>(head, List<A>.Empty));
-      }
-    }
+    public NonEmptyList<A> Reverse => FoldLeft<NonEmptyList<A>>((b, a) => a & b, new NonEmptyList<A>(head, List<A>.Empty));
 
-    public Option<A> this [int n] {
-      get {
-        return n == 0 ? head.Some() : tail[n - 1];
-      }
-    }
+    public Option<A> this [int n] => n == 0 ? head.Some() : tail[n - 1];
 
-    public NonEmptyList<C> ZipWith<B, C>(NonEmptyList<B> bs, Func<A, Func<B, C>> f) {
-      return new NonEmptyList<C>(f(head)(bs.head), tail.ZipWith(bs.tail, f));
-    }
+    public NonEmptyList<C> ZipWith<B, C>(NonEmptyList<B> bs, Func<A, Func<B, C>> f) =>
+      new NonEmptyList<C>(f(head)(bs.head), tail.ZipWith(bs.tail, f));
 
-    public NonEmptyList<Pair<A, B>> Zip<B>(NonEmptyList<B> bs) {
-      return ZipWith<B, Pair<A, B>>(bs, a => b => a.And(b));
-    }
+    public NonEmptyList<Pair<A, B>> Zip<B>(NonEmptyList<B> bs) => ZipWith<B, Pair<A, B>>(bs, a => b => a.And(b));
 
-    public bool All(Func<A, bool> f) {
-      return f(head) && tail.All(f);
-    }
+    public bool All(Func<A, bool> f) => f(head) && tail.All(f);
 
-    public bool Any(Func<A, bool> f) {
-      return f(head) || tail.Any(f);
-    }
+    public bool Any(Func<A, bool> f) => f(head) || tail.Any(f);
 
-    public List<NonEmptyList<B>> TraverseList<B>(Func<A, List<B>> f) {
-      return f(head).ProductWith<List<B>, NonEmptyList<B>>(tail.TraverseList(f), h => t => h & t);
-    }
+    public List<NonEmptyList<B>> TraverseList<B>(Func<A, List<B>> f) =>
+      f(head).ProductWith<List<B>, NonEmptyList<B>>(tail.TraverseList(f), h => t => h & t);
 
-    public Option<NonEmptyList<B>> TraverseOption<B>(Func<A, Option<B>> f) {
-      return f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseOption(f), h => t => h & t);
-    }
+    public Option<NonEmptyList<B>> TraverseOption<B>(Func<A, Option<B>> f) =>
+      f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseOption(f), h => t => h & t);
 
-    public Terminal<NonEmptyList<B>> TraverseTerminal<B>(Func<A, Terminal<B>> f) {
-      return f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseTerminal(f), h => t => h & t);
-    }
+    public Terminal<NonEmptyList<B>> TraverseTerminal<B>(Func<A, Terminal<B>> f) =>
+      f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseTerminal(f), h => t => h & t);
 
-    public Input<NonEmptyList<B>> TraverseInput<B>(Func<A, Input<B>> f) {
-      return f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseInput(f), h => t => h & t);
-    }
+    public Input<NonEmptyList<B>> TraverseInput<B>(Func<A, Input<B>> f) =>
+      f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseInput(f), h => t => h & t);
 
-    public Either<X, NonEmptyList<B>> TraverseEither<X, B>(Func<A, Either<X, B>> f) {
-      return f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseEither(f), h => t => h & t);
-    }
+    public Either<X, NonEmptyList<B>> TraverseEither<X, B>(Func<A, Either<X, B>> f) =>
+      f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseEither(f), h => t => h & t);
 
-    public NonEmptyList<NonEmptyList<B>> TraverseNonEmptyList<B>(Func<A, NonEmptyList<B>> f) {
-      return f(head).ProductWith<List<B>, NonEmptyList<B>>(tail.TraverseNonEmptyList(f), h => t => h & t);
-    }
+    public NonEmptyList<NonEmptyList<B>> TraverseNonEmptyList<B>(Func<A, NonEmptyList<B>> f) =>
+      f(head).ProductWith<List<B>, NonEmptyList<B>>(tail.TraverseNonEmptyList(f), h => t => h & t);
 
-    public Pair<X, NonEmptyList<B>> TraversePair<X, B>(Func<A, Pair<X, B>> f, Monoid<X> m) {
-      return f(head).Constrain(m).ZipWith<List<B>, NonEmptyList<B>>(tail.TraversePair(f, m).Constrain(m), h => t => h & t).Pair;
-    }
+    public Pair<X, NonEmptyList<B>> TraversePair<X, B>(Func<A, Pair<X, B>> f, Monoid<X> m) =>
+      f(head).Constrain(m).ZipWith<List<B>, NonEmptyList<B>>(tail.TraversePair(f, m).Constrain(m), h => t => h & t).Pair;
 
-    public Func<X, NonEmptyList<B>> TraverseFunc<X, B>(Func<A, Func<X, B>> f) {
-      return f(head).ZipWith<B, List<B>, NonEmptyList<B>, X>(tail.TraverseFunc(f), h => t => h & t);
-    }
+    public Func<X, NonEmptyList<B>> TraverseFunc<X, B>(Func<A, Func<X, B>> f) =>
+      f(head).ZipWith<B, List<B>, NonEmptyList<B>, X>(tail.TraverseFunc(f), h => t => h & t);
 
-    public Tree<NonEmptyList<B>> TraverseTree<B>(Func<A, Tree<B>> f) {
-      return f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseTree(f), h => t => h & t);
-    }
+    public Tree<NonEmptyList<B>> TraverseTree<B>(Func<A, Tree<B>> f) =>
+      f(head).ZipWith<List<B>, NonEmptyList<B>>(tail.TraverseTree(f), h => t => h & t);
 
-    public ListZipper<A> Zipper {
-      get {
-        return new ListZipper<A>(List<A>.Empty, head, tail);
-      }
-    }
+    public ListZipper<A> Zipper => new ListZipper<A>(List<A>.Empty, head, tail);
 
   }
 
   public static class NonEmptyListExtension {
-    public static NonEmptyList<B> Select<A, B>(this NonEmptyList<A> ps, Func<A, B> f) {
-      return new NonEmptyList<B>(f(ps.Head.Get), ps.Tail.Get.Select(f));
-    }
+    public static NonEmptyList<B> Select<A, B>(this NonEmptyList<A> ps, Func<A, B> f) =>
+      new NonEmptyList<B>(f(ps.Head.Get), ps.Tail.Get.Select(f));
 
-    public static NonEmptyList<B> SelectMany<A, B>(this NonEmptyList<A> ps, Func<A, NonEmptyList<B>> f) {
-      return f(ps.Head.Get).Append(ps.Tail.Get.SelectMany(a => f(a).List));
-    }
+    public static NonEmptyList<B> SelectMany<A, B>(this NonEmptyList<A> ps, Func<A, NonEmptyList<B>> f) =>
+      f(ps.Head.Get).Append(ps.Tail.Get.SelectMany(a => f(a).List));
 
-    public static NonEmptyList<C> SelectMany<A, B, C>(this NonEmptyList<A> ps, Func<A, NonEmptyList<B>> p, Func<A, B, C> f) {
-      return SelectMany(ps, a => Select(p(a), b => f(a, b)));
-    }
+    public static NonEmptyList<C> SelectMany<A, B, C>(this NonEmptyList<A> ps, Func<A, NonEmptyList<B>> p, Func<A, B, C> f) =>
+      SelectMany(ps, a => Select(p(a), b => f(a, b)));
 
-    public static NonEmptyList<B> Apply<A, B>(this NonEmptyList<Func<A, B>> f, NonEmptyList<A> o) {
-      return f.ProductWith<A, B>(o, a => b => a(b));
-    }
+    public static NonEmptyList<B> Apply<A, B>(this NonEmptyList<Func<A, B>> f, NonEmptyList<A> o) =>
+      f.ProductWith<A, B>(o, a => b => a(b));
 
-    public static NonEmptyList<B> ApplyZip<A, B>(this NonEmptyList<Func<A, B>> f, NonEmptyList<A> o) {
-      return f.ZipWith<A, B>(o, a => b => a(b));
-    }
+    public static NonEmptyList<B> ApplyZip<A, B>(this NonEmptyList<Func<A, B>> f, NonEmptyList<A> o) =>
+      f.ZipWith<A, B>(o, a => b => a(b));
 
-    public static NonEmptyList<A> Flatten<A>(this NonEmptyList<NonEmptyList<A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static NonEmptyList<A> Flatten<A>(this NonEmptyList<NonEmptyList<A>> o) =>
+      o.SelectMany(z => z);
 
-    public static Pair<NonEmptyList<A>, NonEmptyList<B>> Unzip<A, B>(this NonEmptyList<Pair<A, B>> p) {
-      return p.Tail.Get.Unzip().BinarySelect(ta => p.Head.Get._1.Get & ta, tb => p.Head.Get._2.Get & tb);
-    }
+    public static Pair<NonEmptyList<A>, NonEmptyList<B>> Unzip<A, B>(this NonEmptyList<Pair<A, B>> p) =>
+      p.Tail.Get.Unzip().BinarySelect(ta => p.Head.Get._1.Get & ta, tb => p.Head.Get._2.Get & tb);
 
-    public static NonEmptyList<A> NonEmptyListValue<A>(this A a) {
-      return new NonEmptyList<A>(a, List<A>.Empty);
-    }
+    public static NonEmptyList<A> NonEmptyListValue<A>(this A a) => new NonEmptyList<A>(a, List<A>.Empty);
 
     public static NonEmptyList<B> UnfoldNonEmptyList<A, B>(this A a, Func<A, Pair<B, A>> f, Func<A, Option<Pair<B, A>>> g) {
       var aa = f(a);

--- a/src/XSharpx/Option.cs
+++ b/src/XSharpx/Option.cs
@@ -6,8 +6,8 @@ namespace XSharpx {
   public sealed class Option {
     private static readonly Option empty = new Option();
     private Option() { }
-    public static Option Empty { get { return empty; } }
-    public static Option<A> Some<A>(A a) { return Option<A>.Some(a); }
+    public static Option Empty => empty;
+    public static Option<A> Some<A>(A a) => Option<A>.Some(a);
   }
 
   /// <summary>
@@ -24,39 +24,19 @@ namespace XSharpx {
       this.a = a;
     }
 
-    public bool IsEmpty {
-      get {
-        return !ne;
-      }
-    }
+    public bool IsEmpty => !ne;
 
-    public bool IsNotEmpty{
-      get {
-        return ne;
-      }
-    }
+    public bool IsNotEmpty => ne;
 
-    public X Fold<X>(Func<A, X> some, Func<X> empty) {
-      return IsEmpty ? empty() : some(a);
-    }
+    public X Fold<X>(Func<A, X> some, Func<X> empty) => IsEmpty ? empty() : some(a);
 
-    public Option<Option<A>> Duplicate {
-      get {
-        return this.Select(a => a.Some());
-      }
-    }
+    public Option<Option<A>> Duplicate => this.Select(a => a.Some());
 
-    public Option<B> Extend<B>(Func<Option<A>, B> f) {
-      return this.Select(a => f(a.Some()));
-    }
+    public Option<B> Extend<B>(Func<Option<A>, B> f) => this.Select(a => f(a.Some()));
 
-    public Option<C> ZipWith<B, C>(Option<B> o, Func<A, Func<B, C>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public Option<C> ZipWith<B, C>(Option<B> o, Func<A, Func<B, C>> f) => this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public Option<Pair<A, B>> Zip<B>(Option<B> o) {
-      return ZipWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
-    }
+    public Option<Pair<A, B>> Zip<B>(Option<B> o) => ZipWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
 
     public void ForEach(Action<A> a) {
       foreach(A x in this) {
@@ -69,59 +49,35 @@ namespace XSharpx {
       return Fold(a => p(a) ? t : Empty, () => Empty);
     }
 
-    public A ValueOr(Func<A> or) {
-      return IsEmpty ? or() : a;
-    }
+    public A ValueOr(Func<A> or) => IsEmpty ? or() : a;
 
-    public Option<A> OrElse(Func<Option<A>> o) {
-      return IsEmpty ? o() : this;
-    }
+    public Option<A> OrElse(Func<Option<A>> o) => IsEmpty ? o() : this;
 
-    public Option<A> Append(Option<A> o, Semigroup<A> m) {
-      return m.Option.Op(this, o);
-    }
+    public Option<A> Append(Option<A> o, Semigroup<A> m) => m.Option.Op(this, o);
 
-    public bool All(Func<A, bool> f) {
-      return IsEmpty || f(a);
-    }
+    public bool All(Func<A, bool> f) => IsEmpty || f(a);
 
-    public bool Any(Func<A, bool> f) {
-      return !IsEmpty && f(a);
-    }
+    public bool Any(Func<A, bool> f) => !IsEmpty && f(a);
 
-    public List<A> ToList {
-      get {
-        return IsEmpty ? List<A>.Empty : a.ListValue();
-      }
-    }
+    public List<A> ToList => IsEmpty ? List<A>.Empty : a.ListValue();
 
-    public List<Option<B>> TraverseList<B>(Func<A, List<B>> f) {
-      return IsEmpty ? Option<B>.Empty.ListValue() : f(a).Select(q => q.Some());
-    }
+    public List<Option<B>> TraverseList<B>(Func<A, List<B>> f) => IsEmpty ? Option<B>.Empty.ListValue() : f(a).Select(q => q.Some());
 
-    public Option<Option<B>> TraverseOption<B>(Func<A, Option<B>> f) {
-      return IsEmpty ? Option<B>.Empty.Some() : f(a).Select(q => q.Some());
-    }
+    public Option<Option<B>> TraverseOption<B>(Func<A, Option<B>> f) => IsEmpty ? Option<B>.Empty.Some() : f(a).Select(q => q.Some());
 
-    public Terminal<Option<B>> TraverseTerminal<B>(Func<A, Terminal<B>> f) {
-      return IsEmpty ? Option<B>.Empty.TerminalValue() : f(a).Select(q => q.Some());
-    }
+    public Terminal<Option<B>> TraverseTerminal<B>(Func<A, Terminal<B>> f) =>
+      IsEmpty ? Option<B>.Empty.TerminalValue() : f(a).Select(q => q.Some());
 
-    public Input<Option<B>> TraverseInput<B>(Func<A, Input<B>> f) {
-      return IsEmpty ? Option<B>.Empty.InputElement() : f(a).Select(q => q.Some());
-    }
+    public Input<Option<B>> TraverseInput<B>(Func<A, Input<B>> f) => IsEmpty ? Option<B>.Empty.InputElement() : f(a).Select(q => q.Some());
 
-    public Either<X, Option<B>> TraverseEither<X, B>(Func<A, Either<X, B>> f) {
-      return IsEmpty ? Option<B>.Empty.Right<X, Option<B>>() : f(a).Select(q => q.Some());
-    }
+    public Either<X, Option<B>> TraverseEither<X, B>(Func<A, Either<X, B>> f) =>
+      IsEmpty ? Option<B>.Empty.Right<X, Option<B>>() : f(a).Select(q => q.Some());
 
-    public NonEmptyList<Option<B>> TraverseNonEmptyList<B>(Func<A, NonEmptyList<B>> f) {
-      return IsEmpty ? Option<B>.Empty.NonEmptyListValue() : f(a).Select(q => q.Some());
-    }
+    public NonEmptyList<Option<B>> TraverseNonEmptyList<B>(Func<A, NonEmptyList<B>> f) =>
+      IsEmpty ? Option<B>.Empty.NonEmptyListValue() : f(a).Select(q => q.Some());
 
-    public Pair<X, Option<B>> TraversePair<X, B>(Func<A, Pair<X, B>> f, Monoid<X> m) {
-      return IsEmpty ? m.Id.And(Option<B>.Empty) : f(a).Select(q => q.Some());
-    }
+    public Pair<X, Option<B>> TraversePair<X, B>(Func<A, Pair<X, B>> f, Monoid<X> m) =>
+      IsEmpty ? m.Id.And(Option<B>.Empty) : f(a).Select(q => q.Some());
 
     public Func<X, Option<B>> TraverseFunc<X, B>(Func<A, Func<X, B>> f) {
       var z = this;
@@ -129,25 +85,15 @@ namespace XSharpx {
         z.IsEmpty ? Option<B>.Empty : f(z.a)(x).Some();
     }
 
-    public Tree<Option<B>> TraverseTree<B>(Func<A, Tree<B>> f) {
-      return IsEmpty ? Option<B>.Empty.TreeValue() : f(a).Select(q => q.Some());
-    }
+    public Tree<Option<B>> TraverseTree<B>(Func<A, Tree<B>> f) =>
+      IsEmpty ? Option<B>.Empty.TreeValue() : f(a).Select(q => q.Some());
 
-    public static implicit operator Option<A>(Option o)
-    { 
-      // Only instance of Option is Option.Empty. So return forall A.
-      return Empty;
-    }
+    // Only instance of Option is Option.Empty. So return forall A.
+    public static implicit operator Option<A>(Option o) => Empty;
 
-    public static Option<A> Empty {
-      get {
-        return new Option<A>(true, default(A));
-      }
-    }
+    public static Option<A> Empty => new Option<A>(true, default(A));
 
-    public static Option<A> Some(A t) {
-      return new Option<A>(false, t);
-    }
+    public static Option<A> Some(A t) => new Option<A>(false, t);
 
     private A Value {
       get {
@@ -162,49 +108,37 @@ namespace XSharpx {
       if (IsNotEmpty) yield return a;
     }
 
-    public IEnumerator<A> GetEnumerator() {
-      return Enumerate().GetEnumerator();
-    }
+    public IEnumerator<A> GetEnumerator() => Enumerate().GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() {
-      return GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => Enumerate().GetEnumerator();
+
   }
 
   public static class OptionExtension {
-    public static Option<B> Select<A, B>(this Option<A> k, Func<A, B> f) {
-      return k.Fold<Option<B>>(a => Option<B>.Some(f(a)), () => Option.Empty);
-    }
+    public static Option<B> Select<A, B>(this Option<A> k, Func<A, B> f) =>
+      k.Fold<Option<B>>(a => Option<B>.Some(f(a)), () => Option.Empty);
 
-    public static Option<B> SelectMany<A, B>(this Option<A> k, Func<A, Option<B>> f) {
-      return k.Fold(f, () => Option.Empty);
-    }
+    public static Option<B> SelectMany<A, B>(this Option<A> k, Func<A, Option<B>> f) =>
+      k.Fold(f, () => Option.Empty);
 
-    public static Option<C> SelectMany<A, B, C>(this Option<A> k, Func<A, Option<B>> p, Func<A, B, C> f) {
-      return SelectMany(k, a => Select(p(a), b => f(a, b)));
-    }
+    public static Option<C> SelectMany<A, B, C>(this Option<A> k, Func<A, Option<B>> p, Func<A, B, C> f) =>
+      SelectMany(k, a => Select(p(a), b => f(a, b)));
 
-    public static Option<B> Apply<A, B>(this Option<Func<A, B>> f, Option<A> o) {
-      return f.SelectMany(g => o.Select(p => g(p)));
-    }
+    public static Option<B> Apply<A, B>(this Option<Func<A, B>> f, Option<A> o) =>
+      f.SelectMany(g => o.Select(p => g(p)));
 
-    public static Option<A> Flatten<A>(this Option<Option<A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static Option<A> Flatten<A>(this Option<Option<A>> o) =>
+      o.SelectMany(z => z);
 
-    public static Pair<Option<A>, Option<B>> Unzip<A, B>(this Option<Pair<A, B>> p) {
-      return p.IsEmpty ?
+    public static Pair<Option<A>, Option<B>> Unzip<A, B>(this Option<Pair<A, B>> p) =>
+      p.IsEmpty ?
         Option<A>.Empty.And(Option<B>.Empty) :
         Option<A>.Empty.And(Option<B>.Empty);
-    }
 
-    public static Option<A> FromNull<A>(this A a) {
-        return ReferenceEquals(null, a) ? Option<A>.Empty : Option<A>.Some(a);
-    }
+    public static Option<A> FromNull<A>(this A a) =>
+      ReferenceEquals(null, a) ? Option<A>.Empty : Option<A>.Some(a);
 
-    public static Option<A> Some<A>(this A a) {
-      return Option<A>.Some(a);
-    }
+    public static Option<A> Some<A>(this A a) => Option<A>.Some(a);
+
   }
 }
-

--- a/src/XSharpx/Pair.cs
+++ b/src/XSharpx/Pair.cs
@@ -30,71 +30,39 @@ namespace XSharpx {
       }
     }
 
-    public Pair<A, X> Select<X>(Func<B, X> f) {
-      return a.And(f(b));
-    }
+    public Pair<A, X> Select<X>(Func<B, X> f) => a.And(f(b));
 
-    public Pair<A, Pair<A, B>> Duplicate {
-      get {
-        return a.And(a.And(b));
-      }
-    }
+    public Pair<A, Pair<A, B>> Duplicate => a.And(a.And(b));
 
-    public Pair<A, X> Extend<X>(Func<Pair<A, B>, X> f) {
-      return a.And(f(this));
-    }
+    public Pair<A, X> Extend<X>(Func<Pair<A, B>, X> f) => a.And(f(this));
 
-    public Pair<X, B> First<X>(Func<A, X> f) {
-      return f(a).And(b);
-    }
+    public Pair<X, B> First<X>(Func<A, X> f) => f(a).And(b);
 
-    public Pair<A, X> Second<X>(Func<B, X> f) {
-      return a.And(f(b));
-    }
+    public Pair<A, X> Second<X>(Func<B, X> f) => a.And(f(b));
 
-    public Pair<X, Y> BinarySelect<X, Y>(Func<A, X> f, Func<B, Y> g) {
-      return f(a).And(g(b));
-    }
+    public Pair<X, Y> BinarySelect<X, Y>(Func<A, X> f, Func<B, Y> g) => f(a).And(g(b));
 
-    public Pair<B, A> Swap {
-      get {
-        return b.And(a);
-      }
-    }
+    public Pair<B, A> Swap => b.And(a);
 
-    public PairAndSemigroup<A, B> Constrain(Semigroup<A> s) {
-      return new PairAndSemigroup<A, B>(this, s);
-    }
+    public PairAndSemigroup<A, B> Constrain(Semigroup<A> s) => new PairAndSemigroup<A, B>(this, s);
 
-    public PairAndMonoid<A, B> Constrain(Monoid<A> m) {
-      return new PairAndMonoid<A, B>(this, m);
-    }
+    public PairAndMonoid<A, B> Constrain(Monoid<A> m) => new PairAndMonoid<A, B>(this, m);
 
-    public Pair<X, Y> Swapped<X, Y>(Func<Pair<B, A>, Pair<Y, X>> f) {
-      return f(Swap).Swap;
-    }
+    public Pair<X, Y> Swapped<X, Y>(Func<Pair<B, A>, Pair<Y, X>> f) => f(Swap).Swap;
 
-    public X Fold<X>(Func<A, B, X> f) {
-      return f(a, b);
-    }
+    public X Fold<X>(Func<A, B, X> f) => f(a, b);
 
-    public static Pair<A, B> pair(A a, B b) {
-      return new Pair<A, B>(a, b);
-    }
+    public static Pair<A, B> pair(A a, B b) => new Pair<A, B>(a, b);
 
-    public static Func<A, Func<B, Pair<A, B>>> pairF() {
-      return a => b => new Pair<A, B>(a, b);
-    }
+    public static Func<A, Func<B, Pair<A, B>>> pairF() => a => b => new Pair<A, B>(a, b);
+    
   }
 
   public static class PairExtension {
-    public static Pair<X, B> Select<X, A, B>(this Pair<X, A> ps, Func<A, B> f) {
-      return ps._1.Get.And(f(ps._2.Get));
-    }
+    public static Pair<X, B> Select<X, A, B>(this Pair<X, A> ps, Func<A, B> f) => ps._1.Get.And(f(ps._2.Get));
 
-    public static Pair<A, B> And<A, B>(this A a, B b) {
-      return Pair<A, B>.pair(a, b);
-    }
+    public static Pair<A, B> And<A, B>(this A a, B b) => Pair<A, B>.pair(a, b);
+    
   }
 
   public struct PairAndSemigroup<A, B> {
@@ -106,78 +74,45 @@ namespace XSharpx {
       this.s = s;
     }
 
-    public A a {
-      get {
-        return pair._1.Get;
-      }
-    }
+    public A a => pair._1.Get;
 
-    public B b {
-      get {
-        return pair._2.Get;
-      }
-    }
+    public B b => pair._2.Get;
 
-    internal Semigroup<A> S {
-      get {
-        return s;
-      }
-    }
+    internal Semigroup<A> S => s;
 
-    public Pair<A, B> Pair {
-      get {
-        return pair;
-      }
-    }
+    public Pair<A, B> Pair => pair;
 
-    public PairAndSemigroup<A, D> ZipWith<C, D>(PairAndSemigroup<A, C> o, Func<B, Func<C, D>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public PairAndSemigroup<A, D> ZipWith<C, D>(PairAndSemigroup<A, C> o, Func<B, Func<C, D>> f) =>
+      this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public PairAndSemigroup<A, Pair<B, C>> Zip<C>(PairAndSemigroup<A, C> o) {
-      return ZipWith<C, Pair<B, C>>(o, Pair<B, C>.pairF());
-    }
+    public PairAndSemigroup<A, Pair<B, C>> Zip<C>(PairAndSemigroup<A, C> o) =>
+      ZipWith<C, Pair<B, C>>(o, Pair<B, C>.pairF());
 
-    public Pair<X, B> First<X>(Func<A, X> f) {
-      return pair.First(f);
-    }
+    public Pair<X, B> First<X>(Func<A, X> f) => pair.First(f);
 
-    public PairAndSemigroup<A, X> Second<X>(Func<B, X> f) {
-      return new PairAndSemigroup<A, X>(pair.Second(f), s);
-    }
+    public PairAndSemigroup<A, X> Second<X>(Func<B, X> f) => new PairAndSemigroup<A, X>(pair.Second(f), s);
 
-    public Pair<X, Y> BinarySelect<X, Y>(Func<A, X> f, Func<B, Y> g) {
-      return pair.BinarySelect(f, g);
-    }
+    public Pair<X, Y> BinarySelect<X, Y>(Func<A, X> f, Func<B, Y> g) => pair.BinarySelect(f, g);
 
-    public Pair<B, A> Swap {
-      get {
-        return pair.Swap;
-      }
-    }
+    public Pair<B, A> Swap => pair.Swap;
 
-    public Pair<X, Y> Swapped<X, Y>(Func<Pair<B, A>, Pair<Y, X>> f) {
-      return pair.Swapped(f);
-    }
+    public Pair<X, Y> Swapped<X, Y>(Func<Pair<B, A>, Pair<Y, X>> f) => pair.Swapped(f);
 
-    public X Fold<X>(Func<A, B, X> f) {
-      return pair.Fold(f);
-    }
+    public X Fold<X>(Func<A, B, X> f) => pair.Fold(f);
+
   }
 
   public static class PairAndSemigroupExtension {
-    public static PairAndSemigroup<X, B> Select<X, A, B>(this PairAndSemigroup<X, A> ps, Func<A, B> f) {
-      return new PairAndSemigroup<X, B>(ps.Pair.Select(f), ps.S);
-    }
+    public static PairAndSemigroup<X, B> Select<X, A, B>(this PairAndSemigroup<X, A> ps, Func<A, B> f) =>
+      new PairAndSemigroup<X, B>(ps.Pair.Select(f), ps.S);
 
     public static PairAndSemigroup<X, B> SelectMany<X, A, B>(this PairAndSemigroup<X, A> ps, Func<A, PairAndSemigroup<X, B>> f) {
       var r = f(ps.b);
       return new PairAndSemigroup<X, B>(ps.S.Op(ps.a, r.a).And(r.b), ps.S);
     }
 
-    public static PairAndSemigroup<X, C> SelectMany<X, A, B, C>(this PairAndSemigroup<X, A> ps, Func<A, PairAndSemigroup<X, B>> p, Func<A, B, C> f) {
-      return SelectMany(ps, a => Select(p(a), b => f(a, b)));
-    }
+    public static PairAndSemigroup<X, C> SelectMany<X, A, B, C>(this PairAndSemigroup<X, A> ps, Func<A, PairAndSemigroup<X, B>> p, Func<A, B, C> f) =>
+      SelectMany(ps, a => Select(p(a), b => f(a, b)));
   }
 
   public struct PairAndMonoid<A, B> {
@@ -189,77 +124,44 @@ namespace XSharpx {
       this.m = m;
     }
 
-    public A a {
-      get {
-        return pair._1.Get;
-      }
-    }
+    public A a => pair._1.Get;
 
-    public B b {
-      get {
-        return pair._2.Get;
-      }
-    }
+    public B b => pair._2.Get;
 
-    internal Monoid<A> M {
-      get {
-        return m;
-      }
-    }
+    internal Monoid<A> M => m;
 
-    public Pair<A, B> Pair {
-      get {
-        return pair;
-      }
-    }
+    public Pair<A, B> Pair => pair;
 
-    public PairAndMonoid<A, D> ZipWith<C, D>(PairAndMonoid<A, C> o, Func<B, Func<C, D>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public PairAndMonoid<A, D> ZipWith<C, D>(PairAndMonoid<A, C> o, Func<B, Func<C, D>> f) =>
+      this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public PairAndMonoid<A, Pair<B, C>> Zip<C>(PairAndMonoid<A, C> o) {
-      return ZipWith<C, Pair<B, C>>(o, Pair<B, C>.pairF());
-    }
+    public PairAndMonoid<A, Pair<B, C>> Zip<C>(PairAndMonoid<A, C> o) => ZipWith(o, Pair<B, C>.pairF());
 
-    public Pair<X, B> First<X>(Func<A, X> f) {
-      return pair.First(f);
-    }
+    public Pair<X, B> First<X>(Func<A, X> f) => pair.First(f);
 
-    public PairAndMonoid<A, X> Second<X>(Func<B, X> f) {
-      return new PairAndMonoid<A, X>(pair.Second(f), m);
-    }
+    public PairAndMonoid<A, X> Second<X>(Func<B, X> f) => new PairAndMonoid<A, X>(pair.Second(f), m);
 
-    public Pair<X, Y> BinarySelect<X, Y>(Func<A, X> f, Func<B, Y> g) {
-      return pair.BinarySelect(f, g);
-    }
+    public Pair<X, Y> BinarySelect<X, Y>(Func<A, X> f, Func<B, Y> g) => pair.BinarySelect(f, g);
 
-    public Pair<B, A> Swap {
-      get {
-        return pair.Swap;
-      }
-    }
+    public Pair<B, A> Swap => pair.Swap;
 
-    public Pair<X, Y> Swapped<X, Y>(Func<Pair<B, A>, Pair<Y, X>> f) {
-      return pair.Swapped(f);
-    }
+    public Pair<X, Y> Swapped<X, Y>(Func<Pair<B, A>, Pair<Y, X>> f) => pair.Swapped(f);
 
-    public X Fold<X>(Func<A, B, X> f) {
-      return pair.Fold(f);
-    }
+    public X Fold<X>(Func<A, B, X> f) => pair.Fold(f);
+
   }
 
   public static class PairAndMonoidExtension {
-    public static PairAndMonoid<X, B> Select<X, A, B>(this PairAndMonoid<X, A> ps, Func<A, B> f) {
-      return new PairAndMonoid<X, B>(ps.Pair.Select(f), ps.M);
-    }
+    public static PairAndMonoid<X, B> Select<X, A, B>(this PairAndMonoid<X, A> ps, Func<A, B> f) =>
+      new PairAndMonoid<X, B>(ps.Pair.Select(f), ps.M);
 
     public static PairAndMonoid<X, B> SelectMany<X, A, B>(this PairAndMonoid<X, A> ps, Func<A, PairAndMonoid<X, B>> f) {
       var r = f(ps.b);
       return new PairAndMonoid<X, B>(Pair<X, B>.pair(ps.M.Op(ps.a, r.a), r.b), ps.M);
     }
 
-    public static PairAndMonoid<X, C> SelectMany<X, A, B, C>(this PairAndMonoid<X, A> ps, Func<A, PairAndMonoid<X, B>> p, Func<A, B, C> f) {
-      return SelectMany(ps, a => Select(p(a), b => f(a, b)));
-    }
+    public static PairAndMonoid<X, C> SelectMany<X, A, B, C>(this PairAndMonoid<X, A> ps, Func<A, PairAndMonoid<X, B>> p, Func<A, B, C> f) =>
+      SelectMany(ps, a => Select(p(a), b => f(a, b)));
+
   }
 }

--- a/src/XSharpx/Reducer.cs
+++ b/src/XSharpx/Reducer.cs
@@ -10,23 +10,11 @@ namespace XSharpx {
       this.unit = unit;
     }
 
-    public Semigroup<A> Semigroup {
-      get {
-        return Semigroup<A>.semigroup(op);
-      }
-    }
+    public Semigroup<A> Semigroup => Semigroup<A>.semigroup(op);
 
-    public Func<A, A, A> Op {
-      get {
-        return op;
-      }
-    }
+    public Func<A, A, A> Op => op;
 
-    public Func<Q, A> Unit {
-      get {
-        return unit;
-      }
-    }
+    public Func<Q, A> Unit => unit;
 
     public Func<A, Q, A> Snoc {
       get {
@@ -42,31 +30,15 @@ namespace XSharpx {
       }
     }
 
-    public A Apply(A a1, A a2) {
-      return Semigroup.Apply(a1, a2);
-    }
+    public A Apply(A a1, A a2) => Semigroup.Apply(a1, a2);
 
-    public Func<A, Func<A, A>> Curried {
-      get {
-        return Semigroup.Curried;
-      }
-    }
+    public Func<A, Func<A, A>> Curried => Semigroup.Curried;
 
-    public Func<A, A> Curried1(A a1) {
-      return Semigroup.Curried1(a1);
-    }
+    public Func<A, A> Curried1(A a1) => Semigroup.Curried1(a1);
 
-    public Reducer<Q, A> Dual {
-      get {
-        return Semigroup.Dual.Reducer(unit);
-      }
-    }
+    public Reducer<Q, A> Dual => Semigroup.Dual.Reducer(unit);
 
-    public Func<A, A> Join {
-      get {
-        return Semigroup.Join;
-      }
-    }
+    public Func<A, A> Join => Semigroup.Join;
 
     public Reducer<Q, Pair<A, B>> Pair<B>(Reducer<Q, B> s) {
       var t = this;
@@ -85,14 +57,10 @@ namespace XSharpx {
       return Semigroup.XSelect(f, g).Reducer<Q>(q => f(t.unit(q)));
     }
 
-    public static Reducer<Q, A> reducer(Func<A, A, A> op, Func<Q, A> unit) {
-      return new Reducer<Q, A>(op, unit);
-    }
+    public static Reducer<Q, A> reducer(Func<A, A, A> op, Func<Q, A> unit) =>
+      new Reducer<Q, A>(op, unit);
 
-    public static Reducer<A, List<A>> List {
-      get {
-        return Semigroup<A>.List.Reducer<A>(a => a.ListValue());
-      }
-    }
+    public static Reducer<A, List<A>> List => Semigroup<A>.List.Reducer<A>(a => a.ListValue());
+
   }
 }

--- a/src/XSharpx/Semigroup.cs
+++ b/src/XSharpx/Semigroup.cs
@@ -8,25 +8,13 @@ namespace XSharpx {
       this.op = op;
     }
 
-    public Func<A, A, A> Op {
-      get {
-        return op;
-      }
-    }
+    public Func<A, A, A> Op => op;
 
-    public A Apply(A a1, A a2) {
-      return op(a1, a2);
-    }
+    public A Apply(A a1, A a2) => op(a1, a2);
 
-    public Func<A, Func<A, A>> Curried {
-      get {
-        return op.Curry();
-      }
-    }
+    public Func<A, Func<A, A>> Curried => op.Curry();
 
-    public Func<A, A> Curried1(A a1) {
-      return Curried(a1);
-    }
+    public Func<A, A> Curried1(A a1) => Curried(a1);
 
     public Semigroup<A> Dual {
       get {
@@ -81,154 +69,64 @@ namespace XSharpx {
       return new Semigroup<B>((b1, b2) => f(t.op(g(b1), g(b2))));
     }
 
-    public Monoid<A> Monoid(A id) {
-      return Monoid<A>.monoid(op, id);
-    }
+    public Monoid<A> Monoid(A id) => Monoid<A>.monoid(op, id);
 
-    public Reducer<Q, A> Reducer<Q>(Func<Q, A> unit) {
-      return Reducer<Q, A>.reducer(op, unit);
-    }
+    public Reducer<Q, A> Reducer<Q>(Func<Q, A> unit) => Reducer<Q, A>.reducer(op, unit);
 
-    public Reducer<A, A> IdReducer {
-      get {
-        return Reducer<A>(a => a);
-      }
-    }
+    public Reducer<A, A> IdReducer => Reducer<A>(a => a);
 
-    public static Semigroup<A> semigroup(Func<A, A, A> op) {
-      return new Semigroup<A>(op);
-    }
+    public static Semigroup<A> semigroup(Func<A, A, A> op) => new Semigroup<A>(op);
 
-    public static Semigroup<A> Constant(Func<A> a) {
-      return semigroup((a1, a2) => a());
-    }
+    public static Semigroup<A> Constant(Func<A> a) => semigroup((a1, a2) => a());
 
-    public static Semigroup<A> Split1(Func<A, A> f) {
-      return semigroup((a1, _) => f(a1));
-    }
+    public static Semigroup<A> Split1(Func<A, A> f) => semigroup((a1, _) => f(a1));
 
-    public static Semigroup<A> Split2(Func<A, A> f) {
-      return semigroup((_, a2) => f(a2));
-    }
+    public static Semigroup<A> Split2(Func<A, A> f) => semigroup((_, a2) => f(a2));
 
-    public static Semigroup<A> First {
-      get {
-        return semigroup((a1, _) => a1);
-      }
-    }
+    public static Semigroup<A> First => semigroup((a1, _) => a1);
 
-    public static Semigroup<A> Last {
-      get {
-        return semigroup((_, a2) => a2);
-      }
-    }
+    public static Semigroup<A> Last => semigroup((_, a2) => a2);
 
-    public static Semigroup<Option<A>> FirstOption {
-      get {
-        return new Semigroup<Option<A>>((o1, o2) => o1.OrElse(() => o2));
-      }
-    }
+    public static Semigroup<Option<A>> FirstOption => new Semigroup<Option<A>>((o1, o2) => o1.OrElse(() => o2));
 
-    public static Semigroup<Option<A>> SecondOption {
-      get {
-        return new Semigroup<Option<A>>((o1, o2) => o2.OrElse(() => o1));
-      }
-    }
+    public static Semigroup<Option<A>> SecondOption => new Semigroup<Option<A>>((o1, o2) => o2.OrElse(() => o1));
 
-    public static Semigroup<Func<A, A>> Endo {
-      get {
-        return new Semigroup<Func<A, A>>((f1, f2) => f1.Compose(f2));
-      }
-    }
+    public static Semigroup<Func<A, A>> Endo => new Semigroup<Func<A, A>>((f1, f2) => f1.Compose(f2));
 
-    public static Semigroup<List<A>> List {
-      get {
-        return new Semigroup<List<A>>((s1, s2) => s1.Append(s2));
-      }
-    }
+    public static Semigroup<List<A>> List => new Semigroup<List<A>>((s1, s2) => s1.Append(s2));
   }
 
   public static class Semigroup {
-    public static Semigroup<bool> Or {
-      get {
-        return Semigroup<bool>.semigroup((p, q) => p || q);
-      }
-    }
+    public static Semigroup<bool> Or => Semigroup<bool>.semigroup((p, q) => p || q);
 
-    public static Semigroup<bool> And {
-      get {
-        return Semigroup<bool>.semigroup((p, q) => p && q);
-      }
-    }
+    public static Semigroup<bool> And => Semigroup<bool>.semigroup((p, q) => p && q);
 
-    public static Semigroup<string> String {
-      get {
-        return Semigroup<string>.semigroup((s1, s2) => s1 + s2);
-      }
-    }
+    public static Semigroup<string> String => Semigroup<string>.semigroup((s1, s2) => s1 + s2);
 
     public static class Sum {
-      public static Semigroup<int> Integer {
-        get {
-          return Semigroup<int>.semigroup((x, y) => x + y);
-        }
-      }
+      public static Semigroup<int> Integer => Semigroup<int>.semigroup((x, y) => x + y);
 
-      public static Semigroup<byte> Byte {
-        get {
-          return Semigroup<byte>.semigroup((x, y) => (byte)(x + y));
-        }
-      }
+      public static Semigroup<byte> Byte => Semigroup<byte>.semigroup((x, y) => (byte)(x + y));
 
-      public static Semigroup<short> Short {
-        get {
-          return Semigroup<short>.semigroup((x, y) => (short)(x + y));
-        }
-      }
+      public static Semigroup<short> Short => Semigroup<short>.semigroup((x, y) => (short)(x + y));
 
-      public static Semigroup<long> Long {
-        get {
-          return Semigroup<long>.semigroup((x, y) => x + y);
-        }
-      }
+      public static Semigroup<long> Long => Semigroup<long>.semigroup((x, y) => x + y);
 
-      public static Semigroup<char> Char {
-        get {
-          return Semigroup<char>.semigroup((x, y) => (char)(x + y));
-        }
-      }
+      public static Semigroup<char> Char => Semigroup<char>.semigroup((x, y) => (char)(x + y));
+
     }
 
     public static class Product {
-      public static Semigroup<int> Integer {
-        get {
-          return Semigroup<int>.semigroup((x, y) => x * y);
-        }
-      }
+      public static Semigroup<int> Integer => Semigroup<int>.semigroup((x, y) => x * y);
 
-      public static Semigroup<byte> Byte {
-        get {
-          return Semigroup<byte>.semigroup((x, y) => (byte)(x * y));
-        }
-      }
+      public static Semigroup<byte> Byte => Semigroup<byte>.semigroup((x, y) => (byte)(x * y));
 
-      public static Semigroup<short> Short {
-        get {
-          return Semigroup<short>.semigroup((x, y) => (short)(x * y));
-        }
-      }
+      public static Semigroup<short> Short => Semigroup<short>.semigroup((x, y) => (short)(x * y));
 
-      public static Semigroup<long> Long {
-        get {
-          return Semigroup<long>.semigroup((x, y) => x * y);
-        }
-      }
+      public static Semigroup<long> Long => Semigroup<long>.semigroup((x, y) => x * y);
 
-      public static Semigroup<char> Char {
-        get {
-          return Semigroup<char>.semigroup((x, y) => (char)(x * y));
-        }
-      }
+      public static Semigroup<char> Char => Semigroup<char>.semigroup((x, y) => (char)(x * y));
+
     }
   }
 }

--- a/src/XSharpx/Store.cs
+++ b/src/XSharpx/Store.cs
@@ -24,38 +24,20 @@ namespace XSharpx {
       }
     }
 
-    public Func<A, B> Set {
-      get {
-        return set;
-      }
-    }
+    public Func<A, B> Set => set;
 
-    public A Get {
-      get {
-        return get;
-      }
-    }
+    public A Get => get;
 
-    public Store<X, B> XSelect<X>(Func<A, X> f, Func<X, A> g) {
-      return new Store<X, B>(set.Compose(g), f(get));
-    }
+    public Store<X, B> XSelect<X>(Func<A, X> f, Func<X, A> g) => new Store<X, B>(set.Compose(g), f(get));
 
-    public Store<A, Store<A, B>> Duplicate {
-      get {
-        return Extend(q => q);
-      }
-    }
+    public Store<A, Store<A, B>> Duplicate => Extend(q => q);
 
     public Store<A, X> Extend<X>(Func<Store<A, B>, X> f) {
       var t = this;
       return new Store<A, X>(a => f(new Store<A, B>(t.set, a)), get);
     }
 
-    public B Extract {
-      get {
-        return set(get);
-      }
-    }
+    public B Extract => set(get);
 
     public Store<Pair<A, C>, Pair<B, D>> Product<C, D>(Store<C, D> s) {
       var t = this;
@@ -65,18 +47,15 @@ namespace XSharpx {
       );
     }
 
-    public B Modify(Func<A, A> f) {
-      return set(f(get));
-    }
+    public B Modify(Func<A, A> f) => set(f(get));
+
   }
 
   public static class StoreExtension {
-    public static Store<X, B> Select<X, A, B>(this Store<X, A> s, Func<A, B> f) {
-      return new Store<X, B>(f.Compose(s.Set), s.Get);
-    }
+    public static Store<X, B> Select<X, A, B>(this Store<X, A> s, Func<A, B> f) =>
+      new Store<X, B>(f.Compose(s.Set), s.Get);
 
-    public static Store<A, B> StoreSet<A, B>(this A a, Func<A, B> f) {
-      return new Store<A, B>(f, a);
-    }
+    public static Store<A, B> StoreSet<A, B>(this A a, Func<A, B> f) => new Store<A, B>(f, a);
+
   }
 }

--- a/src/XSharpx/Terminal.cs
+++ b/src/XSharpx/Terminal.cs
@@ -26,66 +26,35 @@ namespace XSharpx {
       }
     }
 
-    public bool IsOut {
-      get {
-        return o;
-      }
-    }
+    public bool IsOut => o;
 
-    public bool IsErr {
-      get {
-        return !o;
-      }
-    }
+    public bool IsErr => !o;
 
-    public WriteOp<A> SetOut {
-      get {
-        return new WriteOp<A>(c, val, true);
-      }
-    }
+    public WriteOp<A> SetOut => new WriteOp<A>(c, val, true);
 
-    public WriteOp<A> SetErr {
-      get {
-        return new WriteOp<A>(c, val, false);
-      }
-    }
+    public WriteOp<A> SetErr => new WriteOp<A>(c, val, false);
 
-    public WriteOp<A> Redirect {
-      get {
-        return new WriteOp<A>(c, val, !o);
-      }
-    }
+    public WriteOp<A> Redirect => new WriteOp<A>(c, val, !o);
 
-    public static WriteOp<A> Out(char c, A val) {
-      return new WriteOp<A>(c, val, true);
-    }
+    public static WriteOp<A> Out(char c, A val) => new WriteOp<A>(c, val, true);
 
-    public static WriteOp<A> Err(char c, A val) {
-      return new WriteOp<A>(c, val, false);
-    }
+    public static WriteOp<A> Err(char c, A val) => new WriteOp<A>(c, val, false);
 
     public WriteOp<B> Extend<B>(Func<WriteOp<A>, B> f) {
       var b = f(this);
       return new WriteOp<B>(c, b, o);
     }
 
-    public WriteOp<WriteOp<A>> Duplicate {
-      get {
-        return Extend(z => z);
-      }
-    }
+    public WriteOp<WriteOp<A>> Duplicate => Extend(z => z);
 
-    public Op<A> Op {
-      get {
-        return new Op<A>(this.Right<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>());
-      }
-    }
+    public Op<A> Op => new Op<A>(this.Right<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>());
+  
   }
 
   public static class WriteOpExtension {
-    public static WriteOp<B> Select<A, B>(this WriteOp<A> k, Func<A, B> f) {
-      return new WriteOp<B>(k.Character.Get, f(k.Value.Get), k.IsOut);
-    }
+    public static WriteOp<B> Select<A, B>(this WriteOp<A> k, Func<A, B> f) =>
+      new WriteOp<B>(k.Character.Get, f(k.Value.Get), k.IsOut);
+
   }
 
   public struct Op<A> {
@@ -95,98 +64,50 @@ namespace XSharpx {
       this.val = val;
     }
 
-    public X Fold<X>(Func<Func<int, A>, X> r, Func<Func<string, A>, X> rl, Func<WriteOp<A>, X> p) {
-      return val.Fold(d => d.Fold(r, rl), p);
-    }
+    public X Fold<X>(Func<Func<int, A>, X> r, Func<Func<string, A>, X> rl, Func<WriteOp<A>, X> p) =>
+      val.Fold(d => d.Fold(r, rl), p);
 
-    public bool IsWriteOut {
-      get {
-        return val.Any(o => o.IsOut);
-      }
-    }
+    public bool IsWriteOut => val.Any(o => o.IsOut);
 
-    public bool IsWriteErr {
-      get {
-        return val.Any(o => o.IsErr);
-      }
-    }
+    public bool IsWriteErr => val.Any(o => o.IsErr);
 
-    public bool IsWrite {
-      get {
-        return val.IsRight;
-      }
-    }
+    public bool IsWrite => val.IsRight;
 
-    public bool IsRead {
-      get {
-        return val.Swap.Any(o => o.IsLeft);
-      }
-    }
+    public bool IsRead => val.Swap.Any(o => o.IsLeft);
 
-    public bool IsReadLine {
-      get {
-        return val.Swap.Any(o => o.IsRight);
-      }
-    }
+    public bool IsReadLine => val.Swap.Any(o => o.IsRight);
 
-    public Option<WriteOp<A>> WriteOp {
-      get {
-        return val.ToOption;
-      }
-    }
+    public Option<WriteOp<A>> WriteOp => val.ToOption;
 
-    public Option<char> WriteOpCharacter {
-      get {
-        return WriteOp.Select(o => o.Character.Get);
-      }
-    }
+    public Option<char> WriteOpCharacter => WriteOp.Select(o => o.Character.Get);
 
-    public Option<A> WriteOpValue {
-      get {
-        return WriteOp.Select(o => o.Value.Get);
-      }
-    }
+    public Option<A> WriteOpValue => WriteOp.Select(o => o.Value.Get);
 
-    public Option<Func<int, A>> ReadValue {
-      get {
-        return val.Swap.ToOption.SelectMany(f => f.Swap.ToOption);
-      }
-    }
+    public Option<Func<int, A>> ReadValue => val.Swap.ToOption.SelectMany(f => f.Swap.ToOption);
 
-    public Option<Func<string, A>> ReadLineValue {
-      get {
-        return val.Swap.ToOption.SelectMany(f => f.ToOption);
-      }
-    }
+    public Option<Func<string, A>> ReadLineValue => val.Swap.ToOption.SelectMany(f => f.ToOption);
 
-    public Terminal<A> Lift {
-      get {
-        return new Terminal<A>(this.Select(a => Terminal<A>.Done(a)).Right<A, Op<Terminal<A>>>());
-      }
-    }
+    public Terminal<A> Lift => new Terminal<A>(this.Select(a => Terminal<A>.Done(a)).Right<A, Op<Terminal<A>>>());
 
-    public static Op<A> Read(Func<int, A> f) {
-      return new Op<A>(f.Left<Func<int, A>, Func<string, A>>().Left<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>()); /// new Op<A>(f.Left<Func<int, A>, WriteOp<A>>());
-    }
+    public static Op<A> Read(Func<int, A> f) =>
+      new Op<A>(f.Left<Func<int, A>, Func<string, A>>().Left<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>()); /// new Op<A>(f.Left<Func<int, A>, WriteOp<A>>());
 
-    public static Op<A> ReadLine(Func<string, A> f) {
-      return new Op<A>(f.Right<Func<int, A>, Func<string, A>>().Left<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>()); /// new Op<A>(f.Left<Func<int, A>, WriteOp<A>>());
-    }
 
-    public static Op<A> WriteOut(char c, A a) {
-      return new Op<A>(WriteOp<A>.Out(c, a).Right<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>());
-    }
+    public static Op<A> ReadLine(Func<string, A> f) =>
+      new Op<A>(f.Right<Func<int, A>, Func<string, A>>().Left<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>()); /// new Op<A>(f.Left<Func<int, A>, WriteOp<A>>());
 
-    public static Op<A> WriteErr(char c, A a) {
-      return new Op<A>(WriteOp<A>.Err(c, a).Right<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>());
-    }
+    public static Op<A> WriteOut(char c, A a) =>
+      new Op<A>(WriteOp<A>.Out(c, a).Right<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>());
+
+    public static Op<A> WriteErr(char c, A a) =>
+      new Op<A>(WriteOp<A>.Err(c, a).Right<Either<Func<int, A>, Func<string, A>>, WriteOp<A>>());
 
   }
 
   public static class OpExtension {
-    public static Op<B> Select<A, B>(this Op<A> k, Func<A, B> f) {
-      return k.Fold(q => Op<B>.Read(f.Compose(q)), q => Op<B>.ReadLine(f.Compose(q)), o => o.Select(f).Op);
-    }
+    public static Op<B> Select<A, B>(this Op<A> k, Func<A, B> f) =>
+      k.Fold(q => Op<B>.Read(f.Compose(q)), q => Op<B>.ReadLine(f.Compose(q)), o => o.Select(f).Op);
+
   }
 
   public struct Terminal<A> {
@@ -196,100 +117,70 @@ namespace XSharpx {
       this.val = val;
     }
 
-    public Terminal<C> ZipWith<B, C>(Terminal<B> o, Func<A, Func<B, C>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public Terminal<C> ZipWith<B, C>(Terminal<B> o, Func<A, Func<B, C>> f) =>
+      this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public Terminal<Pair<A, B>> Zip<B>(Terminal<B> o) {
-      return ZipWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
-    }
+    public Terminal<Pair<A, B>> Zip<B>(Terminal<B> o) => ZipWith(o, Pair<A, B>.pairF());
 
-    public static Terminal<A> Done(A a) {
-      return new Terminal<A>(a.Left<A, Op<Terminal<A>>>());
-    }
+    public static Terminal<A> Done(A a) => new Terminal<A>(a.Left<A, Op<Terminal<A>>>());
 
-    internal static Terminal<A> More(Op<Terminal<A>> o) {
-      return new Terminal<A>(o.Right<A, Op<Terminal<A>>>());
-    }
+    internal static Terminal<A> More(Op<Terminal<A>> o) => new Terminal<A>(o.Right<A, Op<Terminal<A>>>());
 
-    public static Terminal<Unit> WriteOut(char c) {
-      return Op<Unit>.WriteOut(c, Unit.Value).Lift;
-    }
+    public static Terminal<Unit> WriteOut(char c) => Op<Unit>.WriteOut(c, Unit.Value).Lift;
 
-    public static Terminal<Unit> WriteErr(char c) {
-      return Op<Unit>.WriteErr(c, Unit.Value).Lift;
-    }
+    public static Terminal<Unit> WriteErr(char c) => Op<Unit>.WriteErr(c, Unit.Value).Lift;
 
-    public static Terminal<int> Read {
-      get {
-        return Op<int>.Read(c => c).Lift;
-      }
-    }
+    public static Terminal<int> Read => Op<int>.Read(c => c).Lift;
 
-    public static Terminal<string> ReadLine {
-      get {
-        return Op<string>.ReadLine(c => c).Lift;
-      }
-    }
+    public static Terminal<string> ReadLine => Op<string>.ReadLine(c => c).Lift;
 
     // CAUTION: unsafe (perform I/O)
     //
     // This function stands in for the interpreter of 'Terminal programs'.
-    public A Run {
-      get {
-        return val.Swap.Reduce(o => o.Fold(
-          r => {
-            var c = Console.Read();
-            return r(c).Run;
-          }
+    public A Run =>
+      val.Swap.Reduce(o => o.Fold(
+        r => {
+          var c = Console.Read();
+          return r(c).Run;
+        }
         , r => {
-            var s = Console.ReadLine();
-            return r(s).Run;
-          }
+          var s = Console.ReadLine();
+          return r(s).Run;
+        }
         , r => {
-            if(r.IsOut) {
-              Console.Write(r.Character);
-              return r.Value.Get.Run;
-            } else {
-              Console.Error.Write(r.Character);
-              return r.Value.Get.Run;
-            }
+          if(r.IsOut) {
+            Console.Write(r.Character);
+            return r.Value.Get.Run;
+          } else {
+            Console.Error.Write(r.Character);
+            return r.Value.Get.Run;
+          }
         }
         ));
-      }
-    }
+     
     // Select, SelectMany, Apply, Zip and friends, 8Monad functions
   }
 
   public static class TerminalExtension {
-    public static Terminal<B> Select<A, B>(this Terminal<A> k, Func<A, B> f) {
-      return k.val.Fold(
+    public static Terminal<B> Select<A, B>(this Terminal<A> k, Func<A, B> f) =>
+      k.val.Fold(
         a => Terminal<B>.Done(f(a))
       , o => Terminal<B>.More(o.Select(t => t.Select(f)))
       );
-    }
 
-    public static Terminal<B> SelectMany<A, B>(this Terminal<A> k, Func<A, Terminal<B>> f) {
-      return k.val.Fold(
+    public static Terminal<B> SelectMany<A, B>(this Terminal<A> k, Func<A, Terminal<B>> f) =>
+      k.val.Fold(
         f
       , o => Terminal<B>.More(o.Select(t => t.SelectMany(f)))
       );
-    }
 
-    public static Terminal<C> SelectMany<A, B, C>(this Terminal<A> k, Func<A, Terminal<B>> p, Func<A, B, C> f) {
-      return SelectMany(k, a => Select(p(a), b => f(a, b)));
-    }
+    public static Terminal<C> SelectMany<A, B, C>(this Terminal<A> k, Func<A, Terminal<B>> p, Func<A, B, C> f) =>
+      SelectMany(k, a => Select(p(a), b => f(a, b)));
 
-    public static Terminal<B> Apply<A, B>(this Terminal<Func<A, B>> f, Terminal<A> o) {
-      return f.SelectMany(g => o.Select(p => g(p)));
-    }
+    public static Terminal<B> Apply<A, B>(this Terminal<Func<A, B>> f, Terminal<A> o) => f.SelectMany(g => o.Select(p => g(p)));
 
-    public static Terminal<A> Flatten<A>(this Terminal<Terminal<A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static Terminal<A> Flatten<A>(this Terminal<Terminal<A>> o) => o.SelectMany(z => z);
 
-    public static Terminal<A> TerminalValue<A>(this A a) {
-      return Terminal<A>.Done(a);
-    }
+    public static Terminal<A> TerminalValue<A>(this A a) => Terminal<A>.Done(a);
   }
 }

--- a/src/XSharpx/Tree.cs
+++ b/src/XSharpx/Tree.cs
@@ -24,150 +24,107 @@ namespace XSharpx {
       }
     }
 
-    public Tree<Tree<A>> Duplicate {
-      get {
-        return this.UnfoldTree(t => t.And(t.children));
-      }
-    }
+    public Tree<Tree<A>> Duplicate => this.UnfoldTree(t => t.And(t.children));
 
-    public Tree<B> Extend<B>(Func<Tree<A>, B> f) {
-      return this.UnfoldTree(t => f(t).And(t.children));
-    }
+    public Tree<B> Extend<B>(Func<Tree<A>, B> f) => this.UnfoldTree(t => f(t).And(t.children));
 
-    public Tree<C> ZipWith<B, C>(Tree<B> o, Func<A, Func<B, C>> f) {
-      return this.SelectMany(a => o.Select(b => f(a)(b)));
-    }
+    public Tree<C> ZipWith<B, C>(Tree<B> o, Func<A, Func<B, C>> f) => this.SelectMany(a => o.Select(b => f(a)(b)));
 
-    public Tree<Pair<A, B>> Zip<B>(Tree<B> o) {
-      return ZipWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
-    }
+    public Tree<Pair<A, B>> Zip<B>(Tree<B> o) => ZipWith<B, Pair<A, B>>(o, Pair<A, B>.pairF());
 
     public Tree<B> ScanRight<B>(Func<A, List<Tree<B>>, B> f) {
       var c = children.Select(t => t.ScanRight(f));
       return f(root, c).TreeNode(c);
     }
 
-    private List<A> Squish(List<A> x) {
-      return root + children.FoldRight((a, b) => a.Squish(b), x);
-    }
+    private List<A> Squish(List<A> x) => root + children.FoldRight((a, b) => a.Squish(b), x);
 
-    public List<A> PreOrder {
-      get {
-        return Squish(List<A>.Empty);
-      }
-    }
+    public List<A> PreOrder => Squish(List<A>.Empty);
 
-    public List<List<A>> BreadthFirst {
-      get {
-        return this.ListValue().UnfoldList<List<Tree<A>>, List<A>>(a =>
+    public List<List<A>> BreadthFirst =>
+      this.ListValue().UnfoldList(a =>
           a.IsEmpty ?
             Option.Empty :
             a.Select(q => q.Root.Get).And(a.SumMapRight(t => t.Children.Get, Monoid<Tree<A>>.List)).Some());
-      }
-    }
 
-    public B FoldRight<B>(Func<A, B, B> f, B b) {
-      return PreOrder.FoldRight(f, b);
-    }
+    public B FoldRight<B>(Func<A, B, B> f, B b) => PreOrder.FoldRight(f, b);
 
-    public B FoldLeft<B>(Func<B, A, B> f, B b) {
-      return PreOrder.FoldLeft(f, b);
-    }
+    public B FoldLeft<B>(Func<B, A, B> f, B b) => PreOrder.FoldLeft(f, b);
 
-    public List<Tree<B>> TraverseList<B>(Func<A, List<B>> f) {
-      return f(root).ProductWith<List<Tree<B>>, Tree<B>>(
+    public List<Tree<B>> TraverseList<B>(Func<A, List<B>> f) =>
+      f(root).ProductWith<List<Tree<B>>, Tree<B>>(
         children.TraverseList(w => w.TraverseList(f))
       , b => bs => b.TreeNode(bs)
       );
-    }
 
-    public Option<Tree<B>> TraverseOption<B>(Func<A, Option<B>> f) {
-      return f(root).ZipWith<List<Tree<B>>, Tree<B>>(
+    public Option<Tree<B>> TraverseOption<B>(Func<A, Option<B>> f) =>
+      f(root).ZipWith<List<Tree<B>>, Tree<B>>(
         children.TraverseOption(w => w.TraverseOption(f))
       , b => bs => b.TreeNode(bs)
       );
-    }
 
-    public Terminal<Tree<B>> TraverseTerminal<B>(Func<A, Terminal<B>> f) {
-      return f(root).ZipWith<List<Tree<B>>, Tree<B>>(
+    public Terminal<Tree<B>> TraverseTerminal<B>(Func<A, Terminal<B>> f) =>
+      f(root).ZipWith<List<Tree<B>>, Tree<B>>(
         children.TraverseTerminal(w => w.TraverseTerminal(f))
       , b => bs => b.TreeNode(bs)
       );
-    }
 
-    public Input<Tree<B>> TraverseInput<B>(Func<A, Input<B>> f) {
-      return f(root).ZipWith<List<Tree<B>>, Tree<B>>(
+    public Input<Tree<B>> TraverseInput<B>(Func<A, Input<B>> f) =>
+      f(root).ZipWith<List<Tree<B>>, Tree<B>>(
         children.TraverseInput(w => w.TraverseInput(f))
       , b => bs => b.TreeNode(bs)
       );
-    }
 
-    public Either<X, Tree<B>> TraverseEither<X, B>(Func<A, Either<X, B>> f) {
-      return f(root).ZipWith<List<Tree<B>>, Tree<B>>(
+    public Either<X, Tree<B>> TraverseEither<X, B>(Func<A, Either<X, B>> f) =>
+      f(root).ZipWith<List<Tree<B>>, Tree<B>>(
         children.TraverseEither(w => w.TraverseEither(f))
       , b => bs => b.TreeNode(bs)
       );
-    }
 
-    public NonEmptyList<Tree<B>> TraverseNonEmptyList<B>(Func<A, NonEmptyList<B>> f) {
-      return f(root).ZipWith<List<Tree<B>>, Tree<B>>(
+    public NonEmptyList<Tree<B>> TraverseNonEmptyList<B>(Func<A, NonEmptyList<B>> f) =>
+      f(root).ZipWith<List<Tree<B>>, Tree<B>>(
         children.TraverseNonEmptyList(w => w.TraverseNonEmptyList(f))
       , b => bs => b.TreeNode(bs)
       );
-    }
 
-    public Pair<X, Tree<B>> TraversePair<X, B>(Func<A, Pair<X, B>> f, Monoid<X> m) {
-      return f(root).Constrain(m).ZipWith<List<Tree<B>>, Tree<B>>(
+    public Pair<X, Tree<B>> TraversePair<X, B>(Func<A, Pair<X, B>> f, Monoid<X> m) =>
+      f(root).Constrain(m).ZipWith<List<Tree<B>>, Tree<B>>(
         children.TraversePair(w => w.TraversePair(f, m), m).Constrain(m)
       , b => bs => b.TreeNode(bs)
       ).Pair;
-    }
 
-    public Func<X, Tree<B>> TraverseFunc<X, B>(Func<A, Func<X, B>> f) {
-      return f(root).ZipWith<B, List<Tree<B>>, Tree<B>, X>(
+    public Func<X, Tree<B>> TraverseFunc<X, B>(Func<A, Func<X, B>> f) =>
+      f(root).ZipWith<B, List<Tree<B>>, Tree<B>, X>(
         children.TraverseFunc<X, Tree<B>>(w => w.TraverseFunc(f))
       , b => bs => b.TreeNode(bs)
       );
-    }
 
-    public Tree<Tree<B>> TraverseTree<B>(Func<A, Tree<B>> f) {
-      return f(root).ZipWith<List<Tree<B>>, Tree<B>>(
+    public Tree<Tree<B>> TraverseTree<B>(Func<A, Tree<B>> f) =>
+      f(root).ZipWith<List<Tree<B>>, Tree<B>>(
         children.TraverseTree(w => w.TraverseTree(f))
       , b => bs => b.TreeNode(bs)
       );
-    }
 
   }
 
   public static class TreeExtension {
-    public static Tree<A> TreeValue<A>(this A a) {
-      return new Tree<A>(a, List<Tree<A>>.Empty);
-    }
+    public static Tree<A> TreeValue<A>(this A a) => new Tree<A>(a, List<Tree<A>>.Empty);
 
-    public static Tree<A> TreeNode<A>(this A a, List<Tree<A>> c) {
-      return new Tree<A>(a, c);
-    }
+    public static Tree<A> TreeNode<A>(this A a, List<Tree<A>> c) => new Tree<A>(a, c);
 
-    public static Tree<B> Select<A, B>(this Tree<A> k, Func<A, B> f) {
-      return f(k.Root.Get).TreeNode(k.Children.Get.Select(q => q.Select(f)));
-    }
+    public static Tree<B> Select<A, B>(this Tree<A> k, Func<A, B> f) => f(k.Root.Get).TreeNode(k.Children.Get.Select(q => q.Select(f)));
 
     public static Tree<B> SelectMany<A, B>(this Tree<A> k, Func<A, Tree<B>> f) {
       var r = f(k.Root.Get);
       return r.Root.Get.TreeNode(r.Children.Get * k.Children.Get.Select(q => q.SelectMany(f)));
     }
 
-    public static Tree<C> SelectMany<A, B, C>(this Tree<A> k, Func<A, Tree<B>> p, Func<A, B, C> f) {
-      return SelectMany(k, a => Select(p(a), b => f(a, b)));
-    }
+    public static Tree<C> SelectMany<A, B, C>(this Tree<A> k, Func<A, Tree<B>> p, Func<A, B, C> f) =>
+      SelectMany(k, a => Select(p(a), b => f(a, b)));
 
-    public static Tree<B> Apply<A, B>(this Tree<Func<A, B>> f, Tree<A> o) {
-      return f.SelectMany(g => o.Select(p => g(p)));
-    }
+    public static Tree<B> Apply<A, B>(this Tree<Func<A, B>> f, Tree<A> o) => f.SelectMany(g => o.Select(p => g(p)));
 
-    public static Tree<A> Flatten<A>(this Tree<Tree<A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static Tree<A> Flatten<A>(this Tree<Tree<A>> o) => o.SelectMany(z => z);
 
     public static Pair<Tree<A>, Tree<B>> Unzip<A, B>(this Tree<Pair<A, B>> p) {
       var c = p.Children.Get.Select(l => l.Unzip());
@@ -176,9 +133,8 @@ namespace XSharpx {
       return p.Root.Get._1.Get.TreeNode(r1).And(p.Root.Get._2.Get.TreeNode(r2));
     }
 
-    public static List<Tree<B>> UnfoldChildren<A, B>(this List<A> a, Func<A, Pair<B, List<A>>> f) {
-       return a.Select(z => z.UnfoldTree(f));
-    }
+    public static List<Tree<B>> UnfoldChildren<A, B>(this List<A> a, Func<A, Pair<B, List<A>>> f) =>
+      a.Select(z => z.UnfoldTree(f));
 
     public static Tree<B> UnfoldTree<A, B>(this A a, Func<A, Pair<B, List<A>>> f) {
       var p = f(a);
@@ -193,49 +149,35 @@ namespace XSharpx {
       this.forest = forest;
     }
 
-    public Store<List<Tree<A>>, TreeForest<A>> Forest {
-      get {
-        return forest.StoreSet(f => new TreeForest<A>(f));
-      }
-    }
+    public Store<List<Tree<A>>, TreeForest<A>> Forest => forest.StoreSet(f => new TreeForest<A>(f));
 
   }
 
   public static class TreeForestExtension {
 
-    public static TreeForest<B> Select<A, B>(this TreeForest<A> k, Func<A, B> f) {
-      return k.Forest.Get.Select(q => q.Select(f)).Forest();
-    }
+    public static TreeForest<B> Select<A, B>(this TreeForest<A> k, Func<A, B> f) =>
+      k.Forest.Get.Select(q => q.Select(f)).Forest();
 
-    public static TreeForest<B> SelectMany<A, B>(this TreeForest<A> k, Func<A, TreeForest<B>> f) {
-      return k.Forest.Get.SelectMany(t => TreeT(a => f(a).Forest.Get, t)).Forest();
-    }
+    public static TreeForest<B> SelectMany<A, B>(this TreeForest<A> k, Func<A, TreeForest<B>> f) =>
+      k.Forest.Get.SelectMany(t => TreeT(a => f(a).Forest.Get, t)).Forest();
 
-    private static List<Tree<B>> TreeT<A, B>(Func<A, List<Tree<B>>> f, Tree<A> t) {
-      return
+    private static List<Tree<B>> TreeT<A, B>(Func<A, List<Tree<B>>> f, Tree<A> t) =>
         from r in f(t.Root.Get)
         from s in t.Children.Get.TraverseList(a => TreeT(f, a))
         select r.Root.Get.TreeNode(s.Append(r.Children.Get));
-    }
 
-    public static TreeForest<C> SelectMany<A, B, C>(this TreeForest<A> k, Func<A, TreeForest<B>> p, Func<A, B, C> f) {
-      return SelectMany(k, a => Select(p(a), b => f(a, b)));
-    }
+    public static TreeForest<C> SelectMany<A, B, C>(this TreeForest<A> k, Func<A, TreeForest<B>> p, Func<A, B, C> f) =>
+      SelectMany(k, a => Select(p(a), b => f(a, b)));
 
-    public static TreeForest<B> Apply<A, B>(this TreeForest<Func<A, B>> f, TreeForest<A> o) {
-      return f.SelectMany(g => o.Select(p => g(p)));
-    }
+    public static TreeForest<B> Apply<A, B>(this TreeForest<Func<A, B>> f, TreeForest<A> o) =>
+      f.SelectMany(g => o.Select(p => g(p)));
 
-    public static TreeForest<A> Flatten<A>(this TreeForest<TreeForest<A>> o) {
-      return o.SelectMany(z => z);
-    }
+    public static TreeForest<A> Flatten<A>(this TreeForest<TreeForest<A>> o) => o.SelectMany(z => z);
 
-    public static Pair<TreeForest<A>, TreeForest<B>> Unzip<A, B>(this TreeForest<Pair<A, B>> p) {
-      return Pair<TreeForest<A>, TreeForest<B>>.pair(p.Select(a => a._1.Get), p.Select(a => a._2.Get));
-    }
+    public static Pair<TreeForest<A>, TreeForest<B>> Unzip<A, B>(this TreeForest<Pair<A, B>> p) =>
+      Pair<TreeForest<A>, TreeForest<B>>.pair(p.Select(a => a._1.Get), p.Select(a => a._2.Get));
 
-    public static TreeForest<A> Forest<A>(this List<Tree<A>> f) {
-      return new TreeForest<A>(f);
-    }
+    public static TreeForest<A> Forest<A>(this List<Tree<A>> f) => new TreeForest<A>(f);
+    
   }
 }


### PR DESCRIPTION
Convert many methods and properties to expression bodied members, and elide type annotations where possible.

This is a purely a syntax change. This only converts those changes that had a return statement as a first statement. Many other methods can be brought to this form with small changes. In particular, there is a class of methods that, apart from the return statement, assign `this` to a `val t`.